### PR TITLE
更新录像页

### DIFF
--- a/back_end/saolei/config/flags.py
+++ b/back_end/saolei/config/flags.py
@@ -1,3 +1,3 @@
-EMAIL_SKIP = True # 是否跳过邮箱验证。用于调试
+EMAIL_SKIP = False # 是否跳过邮箱验证。用于调试
 BAIDU_VERIFY_SKIP = False # 是否跳过审查步骤。用于调试
 DESIGNATOR_SKIP = False # 是否跳过标识检查。用于调试

--- a/back_end/saolei/saolei/settings.py
+++ b/back_end/saolei/saolei/settings.py
@@ -28,7 +28,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 try:
     with open("secrets.json",'r') as f:
         SECRET_KEY = json.load(f)["django_secret_key"]
-except KeyError:
+except:
     SECRET_KEY = "django-insecure-3_(yjnup(rsxz&pd@stz25*meq10bn3m3$lt!n_1+s723#k=ay"
 
 # SECURITY WARNING: don't run with debug turned on in production!

--- a/back_end/saolei/videomanager/view_utils.py
+++ b/back_end/saolei/videomanager/view_utils.py
@@ -16,6 +16,14 @@ for mode in GameModes:
             record_update_fields.append(f"{level}_{stat}_{mode}")
             record_update_fields.append(f"{level}_{stat}_id_{mode}")
 
+def fieldname_translate(name: str):
+    if name in [field.name for field in VideoModel._meta.get_fields()]:
+        return name
+    elif name in [field.name for field in ExpandVideoModel._meta.get_fields()]:
+        return "video__" + name
+    else:
+        return name
+
 # 确定用户破某个纪录后，且对应模式、指标的三个级别全部有录像后，更新redis中的数据
 def update_3_level_cache_record(realname: str, index: str, mode: str, ms_user: UserMS):
     key = f"player_{index}_{mode}_{ms_user.id}"

--- a/back_end/saolei/videomanager/views.py
+++ b/back_end/saolei/videomanager/views.py
@@ -173,9 +173,9 @@ def video_download(request):
 def video_query(request):
     if request.method == 'GET':
         data = request.GET
-        # videos = VideoModel.objects.filter(*data["filter"]).order_by(*data["order_by"]).values(*data["values"])
+
         values = [fieldname_translate(s) for s in data.getlist("v[]")]
-        print(data["r"])
+
         if data["r"] == "true":
             ob = "-" + data["o"]
         else:
@@ -184,12 +184,7 @@ def video_query(request):
             orderby = (ob, "timems")
         else:
             orderby = (ob,)
-        #if index[0] == '-':
-        #    order_index = "-video__" + index[1:]
-        #    values_index = "video__" + index[1:]
-        #else:
-        #    order_index = values_index = "video__" + index
-        print(orderby)
+            
         if data["mode"] != "00":
             filter = {"level": data["level"], "mode": data["mode"]}
             videos = VideoModel.objects.filter(**filter).order_by(*orderby).values(*values)

--- a/back_end/saolei/videomanager/views.py
+++ b/back_end/saolei/videomanager/views.py
@@ -175,6 +175,7 @@ def video_query(request):
         data = request.GET
 
         values = [fieldname_translate(s) for s in data.getlist("v[]")]
+        values.append("id")
 
         if data["r"] == "true":
             ob = "-" + data["o"]

--- a/back_end/saolei/videomanager/views.py
+++ b/back_end/saolei/videomanager/views.py
@@ -3,7 +3,7 @@ import logging
 from django.contrib.auth.decorators import login_required
 from .forms import UploadVideoForm
 from .models import VideoModel, ExpandVideoModel
-from .view_utils import update_personal_record, update_personal_record_stock
+from .view_utils import update_personal_record, update_personal_record_stock, fieldname_translate
 from userprofile.models import UserProfile
 from django.http import HttpResponse, JsonResponse, FileResponse
 import json, urllib
@@ -168,49 +168,41 @@ def video_download(request):
 
 # 录像查询（无需登录）
 # 按任何基础指标+难度+模式，排序，分页
+# 每项的定义参见 front_end/src/views/VideoView.vue 的 request_videos 函数
 @ratelimit(key='ip', rate='20/m')
 def video_query(request):
     if request.method == 'GET':
         data = request.GET
         # videos = VideoModel.objects.filter(*data["filter"]).order_by(*data["order_by"]).values(*data["values"])
-        index = data["index"]
-        if index[0] == '-':
-            order_index = "-video__" + index[1:]
-            values_index = "video__" + index[1:]
+        values = [fieldname_translate(s) for s in data.getlist("v[]")]
+        print(data["r"])
+        if data["r"] == "true":
+            ob = "-" + data["o"]
         else:
-            order_index = values_index = "video__" + index
-
+            ob = data["o"]
+        if data["o"] != "timems":
+            orderby = (ob, "timems")
+        else:
+            orderby = (ob,)
+        #if index[0] == '-':
+        #    order_index = "-video__" + index[1:]
+        #    values_index = "video__" + index[1:]
+        #else:
+        #    order_index = values_index = "video__" + index
+        print(orderby)
         if data["mode"] != "00":
             filter = {"level": data["level"], "mode": data["mode"]}
-            if index in {"id", "upload_time", "bv", "bvs", "-upload_time", "-bv", "-bvs"}:
-                orderby = (index, "timems")
-                values = ("id", "upload_time", "player__realname", "player__id", "bv", "bvs", "timems")
-            elif index == "timems" or index == "-timems":
-                orderby = (index,)
-                values = ("id", "upload_time", "player__realname", "player__id", "bv", "bvs", "timems")
-            else:
-                orderby = (order_index, "timems")
-                values = ("id", "upload_time", "player__realname", "player__id", "bv", "bvs", "timems", values_index)
             videos = VideoModel.objects.filter(**filter).order_by(*orderby).values(*values)
         else:
             filter = {"level": data["level"]}
-            if index in {"id", "upload_time", "bv", "bvs", "-upload_time", "-bv", "-bvs"}:
-                orderby = (index, "timems")
-                values = ("id", "upload_time", "player__realname", "player__id", "bv", "bvs", "timems")
-            elif index == "timems" or index == "-timems":
-                orderby = (index,)
-                values = ("id", "upload_time", "player__realname", "player__id", "bv", "bvs", "timems")
-            else:
-                orderby = (order_index, "timems")
-                values = ("id", "upload_time", "player__realname", "player__id", "bv", "bvs", "timems", values_index)
             videos = VideoModel.objects.filter(Q(mode="00")|Q(mode="12")).filter(**filter).order_by(*orderby).values(*values)
 
         # print(videos)
-        paginator = Paginator(videos, 20)  # 每页20条数据
+        paginator = Paginator(videos, data["ps"])
         page_number = data["page"]
         page_videos = paginator.get_page(page_number)
         response = {
-            "total_page": paginator.num_pages,
+            "count": len(videos),
             "videos": list(page_videos)
             }
         # t=json.dumps(response, cls=ComplexEncoder)

--- a/front_end/src/views/VideoView.vue
+++ b/front_end/src/views/VideoView.vue
@@ -29,12 +29,15 @@
 
     <div style="width: 80%;font-size:20px;margin: auto;margin-top: 10px;">
         <el-table :data="videoList" @sort-change="handleSortChange">
-            <el-table-column type="index" :index="offsetIndex"></el-table-column>
+            <el-table-column type="index" :index="offsetIndex" fixed></el-table-column>
             <el-table-column v-for="key in selected_index()" 
                 :prop="index_tags[key].key" 
                 :label="index_tags[key].name"
                 :formatter="columnFormatter(key)"
                 sortable="custom">
+            </el-table-column>
+            <el-table-column prop="id" v-slot="scope">
+                <el-button @click="preview(scope.row.id)"><i class="el-icon-video-play"></i></el-button>
             </el-table-column>
         </el-table>
     </div>

--- a/front_end/src/views/VideoView.vue
+++ b/front_end/src/views/VideoView.vue
@@ -28,16 +28,13 @@
     </el-row>
 
     <div style="width: 80%;font-size:20px;margin: auto;margin-top: 10px;">
-        <el-table :data="videoList" @sort-change="handleSortChange">
+        <el-table :data="videoList" @sort-change="handleSortChange" @row-click="preview">
             <el-table-column type="index" :index="offsetIndex" fixed></el-table-column>
             <el-table-column v-for="key in selected_index()" 
                 :prop="index_tags[key].key" 
                 :label="index_tags[key].name"
                 :formatter="columnFormatter(key)"
                 sortable="custom">
-            </el-table-column>
-            <el-table-column prop="id" v-slot="scope">
-                <el-button @click="preview(scope.row.id)"><i class="el-icon-video-play"></i></el-button>
             </el-table-column>
         </el-table>
     </div>
@@ -273,7 +270,8 @@ const index_select = (key: string | number, value: NameKeyReverse) => {
     index_tags[key].selected = !value.selected;
 }
 
-const preview = (id: number | undefined) => {
+const preview = (row: any) => {
+    var id = row.id
     if (!id) {
         return
     }

--- a/front_end/src/views/VideoView.vue
+++ b/front_end/src/views/VideoView.vue
@@ -9,91 +9,45 @@
     </Teleport>
     <el-row class="mb-4" style="margin-bottom: 10px;">
         <el-button v-for="(tag, key) in level_tags" type="warning" :plain="!(level_tag_selected == key)" :size="'small'"
-            @click="level_tag_selected = key as string; get_video_rank(1);">{{ tag.name }}</el-button>
+            @click="level_tag_selected = key as string;">{{ tag.name }}</el-button>
     </el-row>
 
     <el-row class="mb-4" style="margin-bottom: 10px;">
         <el-button v-for="(tag, key) in mode_tags" type="success" :plain="!(mode_tag_selected == key)" :size="'small'"
-            @click="mode_tag_selected = key as string; get_video_rank(1);">{{ tag.name }}</el-button>
+            @click="mode_tag_selected = key as string;">{{ tag.name }}</el-button>
     </el-row>
 
     <el-row class="mb-4" style="margin-bottom: 10px;">
         <el-button v-for="(value, key) in index_tags" type="primary" :plain="!value.selected" :size="'small'"
-            @click="console.log(123); index_tags[key].selected = !value.selected; ">{{ value.name
+            @click="index_select(key, value)">{{ value.name
             }}</el-button>
     </el-row>
 
     <el-row class="mb-4" style="margin-bottom: 10px;">
-        <el-button size="small" @click="request_videos">筛选</el-button>
+        <el-button size="small" @click="request_videos">刷新</el-button>
     </el-row>
 
     <div style="width: 80%;font-size:20px;margin: auto;margin-top: 10px;">
-        <div style="border-bottom: 1px solid #555;padding-bottom: 10px;">
-            <div class="rank">排名</div>
-            <span class="utime" :class="{ hoverable: index_tag_selected === 'upload_time' }"
-                :style="{ color: (index_tag_selected === 'upload_time' ? 'rgb(64, 158, 255)' : '') }"
-                @click="reverseSortDirect('upload_time')">上传时间{{
-            index_tag_selected === 'upload_time' ? (index_tags[index_tag_selected].reverse ? "▼" : "▲") : ""
-        }}</span>
-            <span class="name">姓名</span>
-            <span class="bbbv_bbbvs_rtime" :class="{ hoverable: index_tag_selected === 'bbbv' }"
-                :style="{ color: (index_tag_selected === 'bbbv' ? 'rgb(64, 158, 255)' : '') }"
-                @click="reverseSortDirect('bbbv')">3BV{{
-            index_tag_selected === 'bbbv' ? (index_tags[index_tag_selected].reverse ? "▼" : "▲") : "" }}</span>
-            <span class="bbbv_bbbvs_rtime" :class="{ hoverable: index_tag_selected === 'bbbv_s' }"
-                :style="{ color: (index_tag_selected === 'bbbv_s' ? 'rgb(64, 158, 255)' : '') }"
-                @click="reverseSortDirect('bbbv_s')">3BV/s{{
-            index_tag_selected === 'bbbv_s' ? (index_tags[index_tag_selected].reverse ? "▼" : "▲") : "" }}</span>
-            <span class="bbbv_bbbvs_rtime" :class="{ hoverable: index_tag_selected === 'timems' }"
-                :style="{ color: (index_tag_selected === 'timems' ? 'rgb(64, 158, 255)' : '') }"
-                @click="reverseSortDirect('timems')">成绩{{
-            index_tag_selected === 'timems' ? (index_tags[index_tag_selected].reverse ? "▼" : "▲") : "" }}</span>
-            <span v-show="index_visible" class="index"
-                :style="{ color: (index_tag_selected != 'upload_time' && index_tag_selected != 'bbbv' && index_tag_selected != 'bbbv_s' && index_tag_selected != 'timems' ? 'rgb(64, 158, 255)' : '') }"
-                @click="reverseSortDirect(index_tag_selected)">{{
-            index_tag_selected }}{{
-            index_tag_selected != 'upload_time' && index_tag_selected != 'bbbv' && index_tag_selected != 'bbbv_s' &&
-                index_tag_selected != 'timems' ? (index_tags[index_tag_selected].reverse ? "▼" : "▲") : "" }}</span>
-            <!-- <span class="operation">操作</span> -->
-        </div>
-        <div style="height: 770px;">
-            <div v-for="(video, key) in videoData" class="row" @click="preview(video.id)">
-                <div class="rank">{{ state.CurrentPage > 1 ? key - 19 + (state.CurrentPage) * 20 :
-            [..."🥇🥈🥉🏅🏅🏅🏅🏅🏅🏅", 11, 12, 13, 14, 15, 16, 17, 18, 19, 20][key] }}</div>
-
-                <span v-if="'upload_time' in video" class="utime">{{ utc_to_local_format(video.upload_time) }}</span>
-                <span v-else class="utime">{{ utc_to_local_format(video.video__upload_time) }}</span>
-
-                <PlayerName class="name"
-                    :user_id="'player__id' in video ? +(video.player__id as Number) : +(video.video__player__id as Number)"
-                    :user_name="'player__realname' in video ? video.player__realname : video.video__player__realname">
-                </PlayerName>
-                <!-- <span v-if="'player__realname' in video" class="name">{{ video.player__realname }}</span>
-            <span v-else class="name">{{ video.video__player__realname }}</span> -->
-
-                <span v-if="'bv' in video" class="bbbv_bbbvs_rtime">{{ video.bv }}</span>
-                <span v-else class="bbbv_bbbvs_rtime">{{ video.video__bv }}</span>
-
-                <span v-if="'bvs' in video" class="bbbv_bbbvs_rtime">{{ to_fixed_n(video.bvs, 3) }}</span>
-                <span v-else class="bbbv_bbbvs_rtime">{{ to_fixed_n(video.video__bvs, 3) }}</span>
-
-                <span v-if="'timems' in video" class="bbbv_bbbvs_rtime">{{ ms_to_s(video.timems!) }}</span>
-                <span v-else class="bbbv_bbbvs_rtime">{{ ms_to_s(video.video__timems!) }}</span>
-
-                <span v-show="index_visible" class="index">{{
-            to_fixed_n(video["video__" + index_tags[index_tag_selected].key],
-                index_tags[index_tag_selected].to_fixed) }}</span>
-                <!-- <span class="operation">
-                <PreviewDownload :id="video.id"></PreviewDownload>
-            </span> -->
-            </div>
-        </div>
+        <el-table :data="videoList" @sort-change="handleSortChange">
+            <el-table-column type="index" :index="offsetIndex"></el-table-column>
+            <el-table-column v-for="key in selected_index()" 
+                :prop="index_tags[key].key" 
+                :label="index_tags[key].name"
+                :formatter="columnFormatter(key)"
+                sortable="custom">
+            </el-table-column>
+        </el-table>
     </div>
 
     <div style="margin-top: 16px;">
-        <el-pagination v-model:current-page="state.CurrentPage" @current-change="currentChange" @prev-click="prevClick"
-            :next-click="nextClick" :page-size="20" layout="prev, pager, next, jumper" :page-count="state.Total"
-            prev-text="上一页" next-text="下一页">
+        <el-pagination
+            @size-change="handleSizeChange"
+            @current-change="handleCurrentChange"
+            :current-page="state.CurrentPage"
+            :page-sizes="[10, 20, 50, 100]"
+            :page-size="state.PageSize"
+            layout="total, sizes, prev, pager, next, jumper"
+            :total="state.VideoCount">
         </el-pagination>
     </div>
 </template>
@@ -121,27 +75,17 @@ const index_visible = ref(true);
 const state = reactive({
     tableLoading: false,
     CurrentPage: 1,
-    // PageSize: 20,
-    Total: 3,
+    PageSize: 10,
+    VideoCount: 0,
+    Total: 3
 });
 
 // const test  = reactive({v: 5});
 const videoData = reactive<Video[]>([]);
+const videoList = reactive<Video[]>([]);
 // 带下划线与不带的至少存在一个
 interface Video {
-    id: number;
-    upload_time?: string;
-    player__realname?: string;
-    bv?: number;
-    bvs?: number;
-    timems?: number;
-    video__upload_time?: string;
-    video__player__realname?: string;
-    video__bv?: number;
-    video__bvs?: number;
-    video__timems?: number;
-    index?: number;
-    [index: string]: string | number | undefined;
+    [key: string]: string | number; // Assuming all values are strings, change as needed
 }
 
 interface NameKey {
@@ -185,29 +129,60 @@ const mode_tags: Tags = {
 // reverse: true从小到大
 const index_tags: TagsReverse = reactive({
     "upload_time": { name: "上传时间", key: "upload_time", reverse: true, to_fixed: -1, selected: true },
+    "name": { name: "姓名", key: "player__realname", reverse: false, to_fixed: 0, selected: true},
     "timems": { name: "成绩", key: "timems", reverse: false, to_fixed: 3, selected: true },
     "bbbv": { name: "3BV", key: "bv", reverse: false, to_fixed: 0, selected: true },
     "bbbv_s": { name: "3BV/s", key: "bvs", reverse: true, to_fixed: 3, selected: true },
-    "left_s": { name: "left/s", key: "left_s", reverse: true, to_fixed: 3, selected: false },
-    "right_s": { name: "right/s", key: "right_s", reverse: true, to_fixed: 3, selected: false },
-    "double_s": { name: "double/s", key: "double_s", reverse: true, to_fixed: 3, selected: false },
-    "cl_s": { name: "cl/s", key: "cl_s", reverse: true, to_fixed: 3, selected: false },
-    "path": { name: "path", key: "path", reverse: false, to_fixed: 2, selected: false },
-    "stnb": { name: "STNB", key: "stnb", reverse: true, to_fixed: 2, selected: true },
-    "ioe": { name: "IOE", key: "ioe", reverse: true, to_fixed: 3, selected: false },
-    "thrp": { name: "ThrP", key: "thrp", reverse: true, to_fixed: 3, selected: false },
-    "ce_s": { name: "ce/s", key: "ce_s", reverse: true, to_fixed: 3, selected: false },
-    "op": { name: "空", key: "op", reverse: false, to_fixed: 0, selected: false },
-    "is": { name: "岛", key: "isl", reverse: false, to_fixed: 0, selected: false },
-    "cell1": { name: "1", key: "cell1", reverse: false, to_fixed: 0, selected: false },
-    "cell2": { name: "2", key: "cell2", reverse: false, to_fixed: 0, selected: false },
-    "cell3": { name: "3", key: "cell3", reverse: false, to_fixed: 0, selected: false },
-    "cell4": { name: "4", key: "cell4", reverse: false, to_fixed: 0, selected: false },
-    "cell5": { name: "5", key: "cell5", reverse: false, to_fixed: 0, selected: false },
-    "cell6": { name: "6", key: "cell6", reverse: false, to_fixed: 0, selected: false },
-    "cell7": { name: "7", key: "cell7", reverse: false, to_fixed: 0, selected: false },
-    "cell8": { name: "8", key: "cell8", reverse: false, to_fixed: 0, selected: false }
+    "left_s": { name: "left/s", key: "video__left_s", reverse: true, to_fixed: 3, selected: false },
+    "right_s": { name: "right/s", key: "video__right_s", reverse: true, to_fixed: 3, selected: false },
+    "double_s": { name: "double/s", key: "video__double_s", reverse: true, to_fixed: 3, selected: false },
+    "cl_s": { name: "cl/s", key: "video__cl_s", reverse: true, to_fixed: 3, selected: false },
+    "path": { name: "path", key: "video__path", reverse: false, to_fixed: 2, selected: false },
+    "stnb": { name: "STNB", key: "video__stnb", reverse: true, to_fixed: 2, selected: true },
+    "ioe": { name: "IOE", key: "video__ioe", reverse: true, to_fixed: 3, selected: false },
+    "thrp": { name: "ThrP", key: "video__thrp", reverse: true, to_fixed: 3, selected: false },
+    "ce_s": { name: "ce/s", key: "video__ce_s", reverse: true, to_fixed: 3, selected: false },
+    "op": { name: "空", key: "video__op", reverse: false, to_fixed: 0, selected: false },
+    "is": { name: "岛", key: "video__isl", reverse: false, to_fixed: 0, selected: false },
+    "cell1": { name: "1", key: "video__cell1", reverse: false, to_fixed: 0, selected: false },
+    "cell2": { name: "2", key: "video__cell2", reverse: false, to_fixed: 0, selected: false },
+    "cell3": { name: "3", key: "video__cell3", reverse: false, to_fixed: 0, selected: false },
+    "cell4": { name: "4", key: "video__cell4", reverse: false, to_fixed: 0, selected: false },
+    "cell5": { name: "5", key: "video__cell5", reverse: false, to_fixed: 0, selected: false },
+    "cell6": { name: "6", key: "video__cell6", reverse: false, to_fixed: 0, selected: false },
+    "cell7": { name: "7", key: "video__cell7", reverse: false, to_fixed: 0, selected: false },
+    "cell8": { name: "8", key: "video__cell8", reverse: false, to_fixed: 0, selected: false }
 })
+
+const selected_index = () => {
+    var list = [];
+    for (var key of Object.keys(index_tags)) {
+        if (index_tags[key].selected) {
+            list.push(key);
+        }
+    }
+    return list;
+}
+
+const columnFormatter = (key: string) => {
+    if (key == "upload_time") {
+        return (row: any, column: any, cellValue: string | undefined) => {
+            return utc_to_local_format(cellValue);
+        }
+    } else if (key == "timems") {
+        return (row: any, column: any, cellValue: number) => {
+            return ms_to_s(cellValue);
+        }
+    } else if (key == "name") {
+        return (row: any, column: any, cellValue: string) => {
+            return cellValue;
+        }
+    } else {
+        return (row: any, column: any, cellValue: string | number | undefined) => {
+            return to_fixed_n(cellValue, index_tags[key].to_fixed);
+        }
+    }
+}
 
 onMounted(() => {
     document.getElementsByClassName("el-pagination__goto")[0].childNodes[0].nodeValue = "转到";
@@ -215,7 +190,6 @@ onMounted(() => {
 
 
     mod_style();
-    get_video_rank(1);
 })
 
 function to_fixed_n(input: string | number | undefined, to_fixed: number): string | number | undefined {
@@ -240,68 +214,60 @@ const mod_style = () => {
         includes(index_tag_selected.value);
 }
 
-const request_videos = () => {
-    for (var tag of Object.keys(index_tags)) {
-        
+const handleSortChange = (sort: any) => {
+    console.log(sort.prop, sort.order);
+    for (var key of Object.keys(index_tags)) { // 很丑陋，but it works
+        if (index_tags[key].key == sort.prop) {
+            index_tag_selected.value = key;
+            index_tags[key].reverse = sort.order == "descending";
+            break;
+        }
     }
+    request_videos();
+}
+
+const handleSizeChange = (val: number) => {
+    state.PageSize = val;
+    request_videos();
+}
+
+const handleCurrentChange = (val: number) => {
+    state.CurrentPage = val;
+    request_videos();
+}
+
+const offsetIndex = (index: number) => {
+    return state.CurrentPage > 1 ? index - 19 + (state.CurrentPage) * 20 :
+        [..."🥇🥈🥉🏅🏅🏅🏅🏅🏅🏅", 11, 12, 13, 14, 15, 16, 17, 18, 19, 20][index];
 }
 
 // 根据配置，刷新当前页面的录像表
-const get_video_rank = (page: number) => {
-    state.CurrentPage = page
-    let index = index_tags[index_tag_selected.value].key;
-    if (index_tags[index_tag_selected.value].reverse) {
-        index = "-" + index; // 适配django
-    }
+const request_videos = () => {
     proxy.$axios.get('/video/query/',
         {
             params: {
                 level: level_tags[level_tag_selected.value].key,
                 mode: mode_tags[mode_tag_selected.value].key,
-                index: index,
-                page: page,
+                v: ["player__realname"].concat(selected_index().map(function(x) {return index_tags[x].key})), // list of fields
+                o: index_tags[index_tag_selected.value].key, // order by
+                r: index_tags[index_tag_selected.value].reverse, // reverse order
+                ps: state.PageSize, // page size
+                page: state.CurrentPage,
             }
         }
     ).then(function (response) {
         const data = JSON.parse(response.data);
-        if ((data.videos).length >= 0) {
-            videoData.splice(0, videoData.length);
-            videoData.push(...data.videos);
-            state.Total = data.total_page;
-            // console.log(videoData);
-            // console.log(index_tag_selected);
-        } else { }
+        videoList.splice(0, videoList.length);
+        videoList.push(...data.videos);
+        state.VideoCount = data.count;
     }).catch(() => {
         // 触发限流
         ElMessage.error({ message: '请稍后再试', offset: 68 });
     })
 }
 
-const currentChange = (val: number) => {
-    state.CurrentPage = Math.ceil(val);
-    get_video_rank(state.CurrentPage);
-}
-const prevClick = () => {
-    state.CurrentPage = state.CurrentPage - 1;
-    if (state.CurrentPage < 1) {
-        state.CurrentPage = 1;
-    }
-    get_video_rank(state.CurrentPage);
-}
-const nextClick = () => {
-    state.CurrentPage = state.CurrentPage + 1;
-    if (state.CurrentPage > state.Total) {
-        state.CurrentPage = state.Total;
-    }
-    get_video_rank(state.CurrentPage);
-}
-
-// 点标签，改排序方向
-const reverseSortDirect = (index_tag_selected_i: string) => {
-    if (index_tag_selected.value === index_tag_selected_i) {
-        index_tags[index_tag_selected_i].reverse = !index_tags[index_tag_selected_i].reverse;
-    } else { }
-    get_video_rank(state.CurrentPage);
+const index_select = (key: string | number, value: NameKeyReverse) => {
+    index_tags[key].selected = !value.selected;
 }
 
 const preview = (id: number | undefined) => {
@@ -418,5 +384,10 @@ const playVideo = function (uri: string) {
 
 .row:hover {
     background-color: #eee;
+}
+
+.inline-div {
+    display: inline-block;
+    margin: 0;
 }
 </style>

--- a/front_end/src/views/VideoView.vue
+++ b/front_end/src/views/VideoView.vue
@@ -18,9 +18,13 @@
     </el-row>
 
     <el-row class="mb-4" style="margin-bottom: 10px;">
-        <el-button v-for="(tag, key) in index_tags" type="primary" :plain="!(index_tag_selected == key)" :size="'small'"
-            @click="index_tag_selected = key as string; mod_style(); get_video_rank(1);">{{ tag.name
+        <el-button v-for="(value, key) in index_tags" type="primary" :plain="!value.selected" :size="'small'"
+            @click="console.log(123); index_tags[key].selected = !value.selected; ">{{ value.name
             }}</el-button>
+    </el-row>
+
+    <el-row class="mb-4" style="margin-bottom: 10px;">
+        <el-button size="small" @click="request_videos">筛选</el-button>
     </el-row>
 
     <div style="width: 80%;font-size:20px;margin: auto;margin-top: 10px;">
@@ -151,6 +155,7 @@ interface NameKeyReverse {
     key: string;
     reverse: boolean;
     to_fixed: number;
+    selected: boolean;
 }
 interface TagsReverse {
     [index: string]: NameKeyReverse;
@@ -178,31 +183,31 @@ const mode_tags: Tags = {
 
 
 // reverse: true从小到大
-const index_tags: TagsReverse = {
-    "upload_time": { name: "上传时间", key: "upload_time", reverse: true, to_fixed: -1 },
-    "timems": { name: "成绩", key: "timems", reverse: false, to_fixed: 3 },
-    "bbbv": { name: "3BV", key: "bv", reverse: false, to_fixed: 0 },
-    "bbbv_s": { name: "3BV/s", key: "bvs", reverse: true, to_fixed: 3 },
-    "left_s": { name: "left/s", key: "left_s", reverse: true, to_fixed: 3 },
-    "right_s": { name: "right/s", key: "right_s", reverse: true, to_fixed: 3 },
-    "double_s": { name: "double/s", key: "double_s", reverse: true, to_fixed: 3 },
-    "cl_s": { name: "cl/s", key: "cl_s", reverse: true, to_fixed: 3 },
-    "path": { name: "path", key: "path", reverse: false, to_fixed: 2 },
-    "stnb": { name: "STNB", key: "stnb", reverse: true, to_fixed: 2 },
-    "ioe": { name: "IOE", key: "ioe", reverse: true, to_fixed: 3 },
-    "thrp": { name: "ThrP", key: "thrp", reverse: true, to_fixed: 3 },
-    "ce_s": { name: "ce/s", key: "ce_s", reverse: true, to_fixed: 3 },
-    "op": { name: "空", key: "op", reverse: false, to_fixed: 0 },
-    "is": { name: "岛", key: "isl", reverse: false, to_fixed: 0 },
-    "cell1": { name: "1", key: "cell1", reverse: false, to_fixed: 0 },
-    "cell2": { name: "2", key: "cell2", reverse: false, to_fixed: 0 },
-    "cell3": { name: "3", key: "cell3", reverse: false, to_fixed: 0 },
-    "cell4": { name: "4", key: "cell4", reverse: false, to_fixed: 0 },
-    "cell5": { name: "5", key: "cell5", reverse: false, to_fixed: 0 },
-    "cell6": { name: "6", key: "cell6", reverse: false, to_fixed: 0 },
-    "cell7": { name: "7", key: "cell7", reverse: false, to_fixed: 0 },
-    "cell8": { name: "8", key: "cell8", reverse: false, to_fixed: 0 }
-}
+const index_tags: TagsReverse = reactive({
+    "upload_time": { name: "上传时间", key: "upload_time", reverse: true, to_fixed: -1, selected: true },
+    "timems": { name: "成绩", key: "timems", reverse: false, to_fixed: 3, selected: true },
+    "bbbv": { name: "3BV", key: "bv", reverse: false, to_fixed: 0, selected: true },
+    "bbbv_s": { name: "3BV/s", key: "bvs", reverse: true, to_fixed: 3, selected: true },
+    "left_s": { name: "left/s", key: "left_s", reverse: true, to_fixed: 3, selected: false },
+    "right_s": { name: "right/s", key: "right_s", reverse: true, to_fixed: 3, selected: false },
+    "double_s": { name: "double/s", key: "double_s", reverse: true, to_fixed: 3, selected: false },
+    "cl_s": { name: "cl/s", key: "cl_s", reverse: true, to_fixed: 3, selected: false },
+    "path": { name: "path", key: "path", reverse: false, to_fixed: 2, selected: false },
+    "stnb": { name: "STNB", key: "stnb", reverse: true, to_fixed: 2, selected: true },
+    "ioe": { name: "IOE", key: "ioe", reverse: true, to_fixed: 3, selected: false },
+    "thrp": { name: "ThrP", key: "thrp", reverse: true, to_fixed: 3, selected: false },
+    "ce_s": { name: "ce/s", key: "ce_s", reverse: true, to_fixed: 3, selected: false },
+    "op": { name: "空", key: "op", reverse: false, to_fixed: 0, selected: false },
+    "is": { name: "岛", key: "isl", reverse: false, to_fixed: 0, selected: false },
+    "cell1": { name: "1", key: "cell1", reverse: false, to_fixed: 0, selected: false },
+    "cell2": { name: "2", key: "cell2", reverse: false, to_fixed: 0, selected: false },
+    "cell3": { name: "3", key: "cell3", reverse: false, to_fixed: 0, selected: false },
+    "cell4": { name: "4", key: "cell4", reverse: false, to_fixed: 0, selected: false },
+    "cell5": { name: "5", key: "cell5", reverse: false, to_fixed: 0, selected: false },
+    "cell6": { name: "6", key: "cell6", reverse: false, to_fixed: 0, selected: false },
+    "cell7": { name: "7", key: "cell7", reverse: false, to_fixed: 0, selected: false },
+    "cell8": { name: "8", key: "cell8", reverse: false, to_fixed: 0, selected: false }
+})
 
 onMounted(() => {
     document.getElementsByClassName("el-pagination__goto")[0].childNodes[0].nodeValue = "转到";
@@ -233,6 +238,12 @@ const mod_style = () => {
 
     index_visible.value = !["upload_time", "bbbv", "bbbv_s", "timems"].
         includes(index_tag_selected.value);
+}
+
+const request_videos = () => {
+    for (var tag of Object.keys(index_tags)) {
+        
+    }
 }
 
 // 根据配置，刷新当前页面的录像表

--- a/front_end/src/views/VideoView.vue
+++ b/front_end/src/views/VideoView.vue
@@ -237,7 +237,7 @@ const handleCurrentChange = (val: number) => {
 }
 
 const offsetIndex = (index: number) => {
-    return state.CurrentPage > 1 ? index - 19 + (state.CurrentPage) * 20 :
+    return state.CurrentPage > 1 ? index + 1 + (state.CurrentPage - 1) * state.PageSize :
         [..."🥇🥈🥉🏅🏅🏅🏅🏅🏅🏅", 11, 12, 13, 14, 15, 16, 17, 18, 19, 20][index];
 }
 


### PR DESCRIPTION
- 用`<el-table>`显示
- 前后端直接用域的名字交互
- 后端返回总的录像数而不是页数
- 前端可自定义表头包含哪些列并可对任意列排序。
- 页面加载、改筛选条件不会发送请求，点”刷新“按钮、翻页、改排序会发送请求。
- `preview`的参数从录像id改为了整行的数据。目前实际功能没有变化。