### PR TITLE
解决右上角登录状态异常

### DIFF
--- a/front_end/src/App.vue
+++ b/front_end/src/App.vue
@@ -12,7 +12,7 @@
                         <IconMenuItem :text="$t(item.content)" :icon="item.icon" />
                     </el-menu-item>
                     <div style="flex-grow: 1" />
-                    <el-menu-item :index="player_url" v-if="store.user.id != 0" @click="store.player = store.user">
+                    <el-menu-item :index="player_url" v-if="store.user.id != 0">
                         <IconMenuItem :text="store.user.username" icon="User" />
                     </el-menu-item>
                     <el-menu-item index="/settings" style="padding-left: 8px; padding-right: 5px">

--- a/front_end/src/components/Login.vue
+++ b/front_end/src/components/Login.vue
@@ -159,9 +159,6 @@ const AXIOS_BASE_URL = import.meta.env.VITE_BASE_API;
 let refValidCode = ref<any>(null)
 let refValidCode2 = ref<any>(null)
 
-
-const user_name_show = ref(""); // 登录后右上方显示的用户名
-
 // const login_status = ref(LoginStatus.NotLogin);
 // 登录对话框是否出现
 const login_visible = ref(false);
@@ -221,10 +218,6 @@ onMounted(() => {
     } else if (store.login_status == LoginStatus.IsLogin) {
         // 解决改变窗口宽度，使得账号信息在显示和省略之间切换时，用户名不能显示的问题
         hint_message.value = ""
-        user_name_show.value = store.user.username;
-        if (store.user.is_banned) {
-            user_name_show.value += "（您已被封禁，详情请询问管理员！）"
-        }
         emit('login'); // 向父组件发送消息
         login_visible.value = false;
     }
@@ -290,13 +283,8 @@ const login = async () => {
         if (response.data.status == 100) {
             hint_message.value = ""
 
-            user_name_show.value = response.data.msg.username;
-
             store.user = deepCopy(response.data.msg); // 直接赋值会导致user和player共用一个字典！！
             store.player = deepCopy(response.data.msg);
-            if (response.data.msg.is_banned) {
-                user_name_show.value += "（您已被封禁，详情请询问管理员！）"
-            }
             store.login_status = LoginStatus.IsLogin;
             // mutations.updateLoginStatus(LoginStatus.IsLogin);
             // login_status.value = LoginStatus.IsLogin;
@@ -415,7 +403,6 @@ const register = () => {
         // console.log(response.data);
         if (response.data.status == 100) {
             hint_message.value = ""
-            user_name_show.value = user_name_reg.value;
             // login_status.value = LoginStatus.IsLogin;
             // mutations.updateLoginStatus(LoginStatus.IsLogin);
             store.login_status = LoginStatus.IsLogin;
@@ -438,7 +425,6 @@ const logout = async () => {
     ).then(function (response) {
         if (response.data.status == 100) {
             // hint_message.value = ""
-            user_name_show.value = "";
             // login_status.value = LoginStatus.NotLogin;
             // mutations.updateLoginStatus(LoginStatus.NotLogin);
             store.login_status = LoginStatus.NotLogin;

--- a/front_end/src/components/Login.vue
+++ b/front_end/src/components/Login.vue
@@ -151,6 +151,7 @@ const store = useUserStore()
 const local = useLocalStore()
 
 import { useI18n } from 'vue-i18n';
+import { deepCopy } from '@/utils';
 const t = useI18n();
 
 const AXIOS_BASE_URL = import.meta.env.VITE_BASE_API;
@@ -291,8 +292,8 @@ const login = async () => {
 
             user_name_show.value = response.data.msg.username;
 
-            store.user = response.data.msg;
-            store.player = response.data.msg;
+            store.user = deepCopy(response.data.msg); // 直接赋值会导致user和player共用一个字典！！
+            store.player = deepCopy(response.data.msg);
             if (response.data.msg.is_banned) {
                 user_name_show.value += "（您已被封禁，详情请询问管理员！）"
             }
@@ -306,7 +307,7 @@ const login = async () => {
             //     // 如果本次是自动登录成功的，下次依然自动登录
             //     remember_me.value = true;
             // }
-            localStorage.setItem("history_user_id", response.data.id + "");
+            localStorage.setItem("history_user_id", response.data.msg.id + "");
         } else if (response.data.status >= 101) {
             hint_message.value = response.data.msg;
             // console.log("登录失败");
@@ -342,12 +343,11 @@ const retrieve = () => {
     ).then(function (response) {
         if (response.data.status == 100) {
             hint_message.value = "";
-            user_name_show.value = response.data.msg;
             // mutations.updateLoginStatus(LoginStatus.IsLogin);
             store.login_status = LoginStatus.IsLogin;
             // login_status.value = LoginStatus.IsLogin;
-            store.user = response.data.msg;
-            store.player = response.data.msg;
+            store.user = deepCopy(response.data.msg);
+            store.player = deepCopy(response.data.msg);
             emit('login'); // 向父组件发送消息
             retrieve_visible.value = false;
             ElMessage.success({ message: t.t('common.msg.forgetPassword.success'), offset: 68 });
@@ -419,8 +419,8 @@ const register = () => {
             // login_status.value = LoginStatus.IsLogin;
             // mutations.updateLoginStatus(LoginStatus.IsLogin);
             store.login_status = LoginStatus.IsLogin;
-            store.user = response.data.msg;
-            store.player = response.data.msg;
+            store.user = deepCopy(response.data.msg);
+            store.player = deepCopy(response.data.msg);
             emit('login'); // 向父组件发送消息
             register_visible.value = false;
             // console.log(response);

--- a/front_end/src/components/ValidCode.vue
+++ b/front_end/src/components/ValidCode.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="canvas-box" :style="{ height: '32px' }">
+	<div v-loading="loading" class="canvas-box" :style="{ height: '32px' }">
 		<!-- <canvas id="id-canvas2" class="id-canvas2" :width="contentWidth" :height="contentHeight"></canvas> -->
 		<img :src="captchaUrl" alt="" @click="refreshPic()">
 	</div>
@@ -17,9 +17,10 @@ import {  ElMessage } from 'element-plus'
 
 const captchaUrl = ref("")
 const hashkey = ref("")
-
+const loading = ref(true)
 
 const refreshPic = () => {
+	loading.value = true;
 	proxy.$axios.get('/userprofile/refresh_captcha/')
 		.then(function (response) {
 			if (response.data.status == 100) {
@@ -28,6 +29,7 @@ const refreshPic = () => {
 			} else if (response.data.status >= 101) {
 				ElMessage.error({ message: response.data.msg, offset: 68 });
 			}
+			loading.value = false;
 		})
 		.catch(function (error) {
 			console.log(error);

--- a/front_end/src/utils/index.ts
+++ b/front_end/src/utils/index.ts
@@ -47,3 +47,30 @@ export async function freeze(proxy: ComponentCustomProperties & Record<string, a
     }).catch()
     return status
 }
+
+// Credit: ChatGPT
+export function deepCopy<T>(obj: T): T {
+    if (obj === null || typeof obj !== 'object') {
+        return obj;
+    }
+
+    if (obj instanceof Array) {
+        const copy: any[] = [];
+        for (let i = 0; i < obj.length; i++) {
+            copy[i] = deepCopy(obj[i]);
+        }
+        return copy as unknown as T;
+    }
+
+    if (obj instanceof Object) {
+        const copy: { [key: string]: any } = {};
+        for (const key in obj) {
+            if (obj.hasOwnProperty(key)) {
+                copy[key] = deepCopy(obj[key]);
+            }
+        }
+        return copy as T;
+    }
+
+    throw new Error('Unable to copy object! Its type isn\'t supported.');
+}

--- a/front_end/src/utils/system/status.ts
+++ b/front_end/src/utils/system/status.ts
@@ -20,6 +20,6 @@ export function generalNotification(t: any, status: number, action: string) {
         title: t.t(notificationTitle[type], [action]),
         message: t.t(notificationMessage[status]),
         type: notificationType[type],
-        duration: localStorage.getItem('local').notification_duration,
+        duration: JSON.parse(localStorage.getItem('local')).notification_duration,
     })
 }

--- a/front_end/src/views/PlayerView.vue
+++ b/front_end/src/views/PlayerView.vue
@@ -77,7 +77,7 @@
             <el-main>
                 <el-tabs v-model="activeName" style="max-height: 1024px; overflow: auto;">
                     <el-tab-pane :label="$t('profile.records.title')" name="first" :lazy="true">
-                        <PlayerRecordView></PlayerRecordView>
+                        <PlayerRecordView :key="store.player.id"></PlayerRecordView>
                     </el-tab-pane>
                     <el-tab-pane :label="$t('profile.videos')" name="second" :lazy="true">
                         <PlayerVideosView></PlayerVideosView>
@@ -95,9 +95,8 @@
 
 <script lang="ts" setup>
 // 我的地盘页面
-import { onMounted, ref, Ref, defineAsyncComponent, computed } from 'vue'
+import { onMounted, ref, watch } from 'vue'
 import useCurrentInstance from "@/utils/common/useCurrentInstance";
-// import PreviewDownload from '@/components/PreviewDownload.vue';
 import PlayerRecordView from '@/views/PlayerRecordView.vue';
 import PlayerVideosView from '@/views/PlayerVideosView.vue';
 import UploadView from './UploadView.vue';
@@ -112,14 +111,15 @@ import { Plus } from '@element-plus/icons-vue'
 import imageUrlDefault from '@/assets/person.png'
 const imageUrl = ref(imageUrlDefault)
 const avatar_changed = ref(false);
-import { Record, RecordBIE } from "@/utils/common/structInterface";
-import { compress, compressAccurately } from 'image-conversion';
-// import store from '@/store';
+import { Record } from "@/utils/common/structInterface";
+import { compressAccurately } from 'image-conversion';
 import { useUserStore } from '../store'
 const store = useUserStore()
 
 import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
 const t = useI18n();
+const route = useRoute()
 
 const loading = ref(true)
 
@@ -145,7 +145,6 @@ const activeName = ref('first')
 const player = {
     id: -1,
 };
-// console.log(player);
 
 // 上传可能失败，备份旧的头像
 let imageUrlOld: any;
@@ -153,11 +152,8 @@ let imageUrlOld: any;
 // const user = store.user;
 let show_edit_button: boolean;
 
-onMounted(() => {
-    // 把左侧的头像、姓名、个性签名、记录请求过来
-
+function refresh() {
     let player_id = +proxy.$route.params.id;
-    
     // http://localhost:8080/#/player/1
     // 首先看url里有没有带参，如果有，就访问这个用户；其次看store里有没有用户id。
 
@@ -203,10 +199,10 @@ onMounted(() => {
         loading.value = false;
 
     })
+}
 
-    // 再把个人纪录请求过来
-    // std_record
-})
+onMounted(refresh)
+watch(route, refresh) // 解决切换url不刷新的问题
 
 
 // 向后台发送请求修改姓名

--- a/front_end/src/views/PlayerView.vue
+++ b/front_end/src/views/PlayerView.vue
@@ -80,7 +80,7 @@
                         <PlayerRecordView :key="store.player.id"></PlayerRecordView>
                     </el-tab-pane>
                     <el-tab-pane :label="$t('profile.videos')" name="second" :lazy="true">
-                        <PlayerVideosView></PlayerVideosView>
+                        <PlayerVideosView :key="store.player.id"></PlayerVideosView>
                     </el-tab-pane>
                     <el-tab-pane v-if="store.user.id + '' == userid" :label="$t('profile.upload.title')" name="third"
                         :lazy="true">


### PR DESCRIPTION
bug原因：登录时对`store.user`和`store.player`的赋值是引用，导致它们的状态被绑定
解决方案：自定义了`deepCopy`函数（GPT写的）

其他有用的更新：
- 解决了地址栏编辑用户id，网页不刷新的问题。解决方案是监视route，当route变化时执行和`OnMounted`相同的函数。此外也将`PlayerRecordView`和`PlayerVideosView`绑定到了`store.player.id`使其即时刷新
- 图片验证码使用`v-loading`显示加载动画，这样当验证码加载失败时不会是空白的