### PR TITLE
教程页本地化

### DIFF
--- a/front_end/src/App.vue
+++ b/front_end/src/App.vue
@@ -107,7 +107,7 @@ onMounted(() => {
     }
 
     console.log(`
-  元扫雷网(fff666.top)开发团队，期待您的加入: 2234208506@qq.com
+  开源扫雷网(fff666.top)开发团队，期待您的加入: 2234208506@qq.com
   `);
     router.isReady().then(() => {
         menu_index.value = router.currentRoute.value.fullPath;
@@ -193,7 +193,7 @@ body {
 }
 
 .logo2 {
-    width: v-bind("local.menu_height * 2.17 + 'px'");
+    width: v-bind("local.menu_height * 2.5 + 'px'");
     height: v-bind("local.menu_height + 'px'");
     display: inline-flex;
 }

--- a/front_end/src/components/Footer.vue
+++ b/front_end/src/components/Footer.vue
@@ -24,7 +24,7 @@
         </el-row>
         <div style="text-align: center">
             <el-text style="vertical-align: middle">Copyright @ 2023　</el-text>
-            <el-link href="http://fff666.top">元扫雷网 fff666.top</el-link>
+            <el-link href="http://fff666.top">开源扫雷网 fff666.top</el-link>
             <el-text style="vertical-align: middle">　版权所有　</el-text>
             <el-link href="https://beian.miit.gov.cn/">苏ICP备2023056839号-1</el-link>
             <span style="width: 12px; display: inline-block"></span>

--- a/front_end/src/i18n/locales/en.ts
+++ b/front_end/src/i18n/locales/en.ts
@@ -94,6 +94,12 @@ export const en = {
         password: 'new password',
         success: 'Password reset complete!'
     },
+    guide: {
+        announcement: 'Announcements',
+        other: 'Others',
+        skill: 'Skills',
+        tutorial: 'Tutorials',
+    },
     home: {
         news: 'News',
         latestScore: 'Latest',

--- a/front_end/src/i18n/locales/zh-cn.ts
+++ b/front_end/src/i18n/locales/zh-cn.ts
@@ -94,6 +94,12 @@ export const zhCn = {
         password: '请输入新的6-20位密码',
         success: '修改密码成功！',
     },
+    guide: {
+        announcement: '公告',
+        other: '其他',
+        skill: '技术',
+        tutorial: '教程',
+    },
     home: {
         news: '新闻',
         latestScore: '最新录像',

--- a/front_end/src/views/GuideView.vue
+++ b/front_end/src/views/GuideView.vue
@@ -1,14 +1,13 @@
 <template>
     <el-row class="tac">
-        <el-col :span="4">
-            <h5 class="mb-2">目录</h5>
-            <el-menu @select="show_content" class="el-menu-vertical">
+        <el-aside width="auto" @mouseover="isCollapse=false" @mouseleave="isCollapse=true">
+            <el-menu @select="show_content" class="el-menu-vertical" :collapse="isCollapse">
                 <el-sub-menu index="1">
                     <template #title>
                         <el-icon>
                             <Document />
                         </el-icon>
-                        <span>公告</span>
+                        <span>{{ $t('guide.announcement') }}</span>
                     </template>
                     <template v-for="(item, idx) in notice_list">
                         <el-menu-item v-if="item.name[0] == '['" :index="`1-${idx + 1}`">
@@ -27,7 +26,7 @@
                         <el-icon>
                             <Guide />
                         </el-icon>
-                        <span>教程</span>
+                        <span>{{ $t('guide.tutorial') }}</span>
                     </template>
                     <template v-for="(item, idx) in guide_list">
                         <el-menu-item v-if="item.name[0] == '['" :index="`2-${idx + 1}`">
@@ -46,7 +45,7 @@
                         <el-icon>
                             <Cpu />
                         </el-icon>
-                        <span>技术</span>
+                        <span>{{ $t('guide.skill') }}</span>
                     </template>
                     <template v-for="(item, idx) in tech_list">
                         <el-menu-item v-if="item.name[0] == '['" :index="`3-${idx + 1}`">
@@ -65,7 +64,7 @@
                         <el-icon>
                             <Grid />
                         </el-icon>
-                        <span>其他</span>
+                        <span>{{ $t('guide.other') }}</span>
                     </template>
                     <template v-for="(item, idx) in other_list">
                         <el-menu-item v-if="item.name[0] == '['" :index="`4-${idx + 1}`">
@@ -80,12 +79,12 @@
                     </template>
                 </el-sub-menu>
             </el-menu>
-        </el-col>
+        </el-aside>
 
 
-        <el-col :span="20">
+        <el-main>
             <div style="padding-top: 20px;padding-left: 60px;" v-html="article_html" />
-        </el-col>
+        </el-main>
     </el-row>
 </template>
 
@@ -115,6 +114,10 @@ import { imgSize } from "@mdit/plugin-img-size";
 
 // 局面数字的svg数据，原始尺寸都是160*160
 import { cells } from "@/utils/common/cellSVGData";
+import { useI18n } from 'vue-i18n';
+const t = useI18n();
+
+const isCollapse = ref(false);
 
 const markdown = new MarkdownIt({
     html: true, // 允许HTML语法


### PR DESCRIPTION
其他改动：
- 一些地方的网站名字还没有改
- 教程页布局从`el-col`改成`el-aside`和`el-main`
- 教程页菜单自动展开收起
- 网站改名后logo变大，style适配