### PR TITLE
添加LazyTooltip以及若干应用

### DIFF
--- a/front_end/src/components/VideoList.vue
+++ b/front_end/src/components/VideoList.vue
@@ -20,9 +20,12 @@
                 <SoftwareIcon :software="scope.row.software"/>
             </template>
         </el-table-column>
-        <el-table-column prop="level" :formatter="simple_formatter((l: string) => $t('common.level.' + l))"
-            :filters="[{ text: $t('common.level.b'), value: 'b' }, { text: $t('common.level.i'), value: 'i' }, { text: $t('common.level.e'), value: 'e' }]"
-            :filter-method="defaultFilterMethod" :filter-multiple="false" />
+        <el-table-column :filters="[{ text: $t('common.level.b'), value: 'b' }, { text: $t('common.level.i'), value: 'i' }, { text: $t('common.level.e'), value: 'e' }]"
+        :filter-method="defaultFilterMethod" :filter-multiple="false">
+            <template #default="scope">
+                <GameLevelIcon :level="scope.row.level" />
+            </template>
+        </el-table-column>
         <el-table-column prop="mode" :formatter="simple_formatter((mode: string) => $t('common.mode.' + mode))" :filters="[{ text: $t('common.mode.std'), value: 'std' }, { text: $t('common.mode.nf'), value: 'nf' }, { text: $t('common.mode.ng'), value: 'ng' }, { text: $t('common.mode.dg'), value: 'dg' }]" :filter-method="defaultFilterMethod" :filter-multiple="false" />
         <el-table-column prop="timems" :formatter="simple_formatter((timems: number) => (ms_to_s(timems) + 's'))" sortable/>
         <el-table-column prop="bv" sortable/>
@@ -42,6 +45,7 @@ import { utc_to_local_format } from "@/utils/system/tools";
 import PlayerName from '@/components/PlayerName.vue';
 import VideoStateIcon from '@/components/widgets/VideoStateIcon.vue';
 import SoftwareIcon from '@/components/widgets/SoftwareIcon.vue';
+import GameLevelIcon from './widgets/GameLevelIcon.vue';
 import { preview } from '@/utils/common/PlayerDialog';
 
 import { ms_to_s, simple_formatter, defaultFilterMethod } from '@/utils';

--- a/front_end/src/components/widgets/GameLevelIcon.vue
+++ b/front_end/src/components/widgets/GameLevelIcon.vue
@@ -1,0 +1,35 @@
+<template>
+    <el-text v-if="level == 'b'">
+        <LazyTooltip content="8x8/10" hide-after="0" show-after="500">
+            {{ $t('common.level.b') }}
+        </LazyTooltip>
+    </el-text>
+    <el-text v-else-if="level == 'i'">
+        <LazyTooltip content="16x16/40" hide-after="0" show-after="500">
+            {{ $t('common.level.i') }}
+        </LazyTooltip>
+    </el-text>
+    <el-text v-else-if="level == 'e'">
+        <LazyTooltip content="30x16/99" hide-after="0" show-after="500">
+            {{ $t('common.level.e') }}
+        </LazyTooltip>
+    </el-text>
+    <el-text v-else type="danger">
+        <QuestionFilled style="width: 16px; height: 16px"/>
+    </el-text>
+</template>
+
+<script setup lang="ts">
+
+import { useI18n } from 'vue-i18n';
+import LazyTooltip from './LazyTooltip.vue';
+
+const data = defineProps({
+    level: {
+        type: String,
+        default: "z",
+    },
+});
+
+const t = useI18n();
+</script>

--- a/front_end/src/components/widgets/LazyTooltip.vue
+++ b/front_end/src/components/widgets/LazyTooltip.vue
@@ -1,0 +1,20 @@
+<!-- el-tooltip 存在渲染性能问题 -->
+<!-- Credit: https://www.cnblogs.com/zerofan/p/17282121.html -->
+<!-- 注意：该组件受到全局设置 local.tooltip_show 影响 -->
+<template>
+    <el-tooltip v-if="local.tooltip_show && render" v-bind="$attrs" @mouseleave="render=false">
+        <slot />
+    </el-tooltip>
+    <div v-else @mouseenter="render=local.tooltip_show"><slot/></div>
+</template>
+
+<script setup lang="ts">
+
+import { useLocalStore } from '@/store';
+import { ref } from 'vue';
+
+const local = useLocalStore();
+
+const render = ref<Boolean>(false);
+
+</script>

--- a/front_end/src/components/widgets/SoftwareIcon.vue
+++ b/front_end/src/components/widgets/SoftwareIcon.vue
@@ -1,9 +1,13 @@
 <template>
     <el-text v-if="software == 'a'">
-        <img style="width: 16px; height: 16px" src="../../assets/img/ms_arbiter_MAINICON.ico"/>
+        <LazyTooltip content="Minesweeper Arbiter" hide-after="0" show-after="500">
+            <img style="width: 16px; height: 16px" src="../../assets/img/ms_arbiter_MAINICON.ico"/>
+        </LazyTooltip>
     </el-text>
     <el-text v-else-if="software == 'e'">
-        <img style="width: 16px; height: 16px" src="../../assets/img/img_meta.png"/>
+        <LazyTooltip :content="$t('common.software.metasweeper')" hide-after="0" show-after="500">
+            <img style="width: 16px; height: 16px" src="../../assets/img/img_meta.png"/>
+        </LazyTooltip>
     </el-text>
     <el-text v-else type="danger">
         <QuestionFilled style="width: 16px; height: 16px"/>
@@ -11,10 +15,16 @@
 </template>
 
 <script setup lang="ts">
+
+import { useI18n } from 'vue-i18n';
+import LazyTooltip from './LazyTooltip.vue';
+
 const data = defineProps({
     software: {
         type: String,
         default: "z",
     },
 });
+
+const t = useI18n();
 </script>

--- a/front_end/src/components/widgets/VideoStateIcon.vue
+++ b/front_end/src/components/widgets/VideoStateIcon.vue
@@ -1,6 +1,8 @@
 <template>
     <el-text v-if="state == 'd'" type="warning">
-        <Warning />
+        <LazyTooltip :content="$t('common.state.d')" hide-after="0" show-after="500">
+            <Warning />
+        </LazyTooltip>
     </el-text>
     <el-text v-else-if="state == 'c'" type="success">
         <CircleCheck />
@@ -11,10 +13,16 @@
 </template>
 
 <script setup lang="ts">
+
+import { useI18n } from 'vue-i18n';
+import LazyTooltip from './LazyTooltip.vue';
+
 const data = defineProps({
     state: {
         type: String,
         default: "z",
     },
 });
+
+const t = useI18n();
 </script>

--- a/front_end/src/i18n/locales/en.ts
+++ b/front_end/src/i18n/locales/en.ts
@@ -83,6 +83,12 @@ export const en = {
             metasweeper_int: '',
             arbiter_int: '',
         },
+        state: {
+            a: 'Pending',
+            b: 'Frozen',
+            c: 'Valid',
+            d: 'Identifier Mismatch',
+        },
         toDo: 'TODO',
     },
     footer: {
@@ -219,6 +225,10 @@ export const en = {
         menuLayout: 'Menu Layout',
         menuLayoutAbstract: 'Abstract',
         menuLayoutDefault: 'Default',
+        newUserGuide: 'Get Help',
+        newUserGuideTooltip: 'Get help by hovering over components',
+        notificationDuration: 'Notification Duration',
+        notificationDurationTooltip: 'Duration before close. <br />It will not automatically close if set 0.',
     },
     team: {
         title: 'Team',

--- a/front_end/src/i18n/locales/zh-cn.ts
+++ b/front_end/src/i18n/locales/zh-cn.ts
@@ -225,6 +225,10 @@ export const zhCn = {
         menuLayout: '菜单排版',
         menuLayoutAbstract: '抽象',
         menuLayoutDefault: '默认',
+        newUserGuide: '新手引导',
+        newUserGuideTooltip: '鼠标在各种地方悬停时获取帮助。',
+        notificationDuration: '通知时长',
+        notificationDurationTooltip: '显示的时间，单位毫秒。<br />值为0则不会自动关闭。',
     },
     team: {
         title: '团队',

--- a/front_end/src/store/index.ts
+++ b/front_end/src/store/index.ts
@@ -45,6 +45,7 @@ export const useLocalStore = defineStore('local', {
         menu_height: 60,
         menu_icon: false,
         notification_duration: 4500,
+        tooltip_show: true,
     }),
     persist: true,
 })

--- a/front_end/src/views/SettingView.vue
+++ b/front_end/src/views/SettingView.vue
@@ -14,12 +14,19 @@
         </el-descriptions-item>
         <el-descriptions-item :label="t.t('setting.menuFontSize')"><el-input-number v-model="local.menu_font_size"
                 size="small" :min="10" /></el-descriptions-item>
-        <el-descriptions-item label="通知关闭"><el-tooltip>
+        <el-descriptions-item :label="$t('setting.notificationDuration')"><el-tooltip>
                 <template #content>
-                    通知自动关闭的时间，单位毫秒。<br />值为0则不会自动关闭。
+                    <div v-html="$t('setting.notificationDurationTooltip')"/>
                 </template>
                 <el-input-number v-model="local.notification_duration" size="small" :min="0" :step="1000" />
             </el-tooltip></el-descriptions-item>
+        <el-descriptions-item :label="$t('setting.newUserGuide')"><el-tooltip>
+            <template #content>
+                <div v-html="$t('setting.newUserGuideTooltip')"/>
+            </template>
+            <el-switch v-model="local.tooltip_show"></el-switch>
+        </el-tooltip>
+        </el-descriptions-item>
     </el-descriptions>
     <el-descriptions v-if="false && store.login_status == LoginStatus.IsLogin" title="个人信息" :column="3">
         <el-descriptions-item label="用户id">{{ store.user.id }}</el-descriptions-item>


### PR DESCRIPTION
- 添加一个对性能没有影响的`LazyTooltip`，API和`el-tooltip`一致
- 到处都有tooltip可能比较烦人，设置中增加一项“新手引导”控制`LazyTooltip`的开关。
- 在`SoftwareIcon`和`VideoStateIcon`中使用`LazyTooltip`
- 添加`GameLevelIcon`并应用于`VideoList`
- 本地化工作