### PR TITLE
修复录像上传失败

### DIFF
--- a/front_end/src/views/UploadView.vue
+++ b/front_end/src/views/UploadView.vue
@@ -143,7 +143,7 @@ const push_video_msg = async (uploadFile: UploadFile | UploadRawFile) => {
             timems: aa.get_rtime_ms,
             bbbv: aa.get_bbbv,
             bvs: aa.get_bbbv_s,
-            identifier: decoder.decode(aa.get_player_designator), // 以后应改为get_player_identifier
+            identifier: decoder.decode(aa.get_player_identifier), // 以后应改为get_player_identifier
             review_code: aa.is_valid(),
         }
         ext_stat = get_ext_stat(aa)


### PR DESCRIPTION
原因：上游ms_toollib将标识修改为了identifier，而前端调用未修改
预防：上游应当保留旧的接口（obsolete），并在调用该接口时给出警告。多个版本后再删除接口