### PR TITLE
解决bvs的除0错误

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -55,5 +55,8 @@ jobs:
     - name: Flags
       run: python -m unittest tests.py -v
 
+    - name: Video Manager
+      run: python manage.py test videomanager
+      
     - name: Account Link
       run: python manage.py test accountlink

--- a/back_end/saolei/videomanager/models.py
+++ b/back_end/saolei/videomanager/models.py
@@ -98,7 +98,7 @@ class VideoModel(models.Model):
     timems = models.PositiveIntegerField(default=DefaultRankingScores["timems"]) # 整数形式存储的毫秒数。
     # 0-32767
     bv = models.PositiveSmallIntegerField()
-    bvs = models.GeneratedField(expression = models.F('bv') / models.F('timems') * models.Value(1000), output_field = models.FloatField(), db_persist = True)
+    bvs = models.GeneratedField(expression = models.Case(models.When(timems=0,then=models.Value(0.0)), default=models.F('bv') / models.F('timems') * models.Value(1000), output_field = models.FloatField()), output_field = models.FloatField(), db_persist = True)
 
     # 暂时的解决方案
     def __getattr__(self, name):

--- a/back_end/saolei/videomanager/tests.py
+++ b/back_end/saolei/videomanager/tests.py
@@ -1,3 +1,14 @@
 from django.test import TestCase
+from userprofile.models import UserProfile
+from .models import VideoModel, ExpandVideoModel
 
 # Create your tests here.
+
+class VideoManagerTestCase(TestCase):
+    def setUp(self):
+        self.user = UserProfile.objects.create(username='setUp', email='setUp@test.com')
+
+    def test_zero_time(self):
+        expandvideo = ExpandVideoModel.objects.create(identifier='test', left=1, right=0, double=0, cl=1, left_s=0, right_s=0, double_s=0, cl_s=0, path=0, flag=0, flag_s=0, stnb=0, rqp=0, ioe=1, thrp=1, corr=1, ce=1, ce_s=0, op=1, isl=0, cell0=0, cell1=0, cell2=0, cell3=0, cell4=0, cell5=0, cell6=0, cell7=0, cell8=0)
+        video = VideoModel.objects.create(player=self.user, file='test.evf', video=expandvideo, state='a', software='e', level='b', mode='00', timems=0, bv=1)
+        self.assertEqual(video.bvs, 0)


### PR DESCRIPTION
MySQL不支持NaN和Inf，所以使用0.0作为默认值。