### PR TITLE
gzip压缩response

### DIFF
--- a/back_end/saolei/saolei/settings.py
+++ b/back_end/saolei/saolei/settings.py
@@ -72,6 +72,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     'django_ratelimit.middleware.RatelimitMiddleware',
+    'django.middleware.gzip.GZipMiddleware',
 ]
 
 ROOT_URLCONF = "saolei.urls"


### PR DESCRIPTION
经测试，访问一个240录像用户主页，使用该middleware前响应大小34082B，使用后响应大小3683B