### PR TITLE
优化前端加载性能

### DIFF
--- a/front_end/package.json
+++ b/front_end/package.json
@@ -54,6 +54,7 @@
     "less": "^4.1.3",
     "typescript": ">=5.0.0",
     "vite": "^6.0.7",
+    "vite-plugin-compression": "^0.5.1",
     "vite-plugin-top-level-await": "^1.4.1",
     "vite-plugin-wasm": "^3.3.0"
   }

--- a/front_end/src/components/AccountLinkManager.vue
+++ b/front_end/src/components/AccountLinkManager.vue
@@ -85,10 +85,10 @@ import { store, local } from '@/store';
 import { ElNotification } from 'element-plus';
 import { Platform, platformlist } from '@/utils/common/accountLinkPlatforms'
 import PlatformIcon from './widgets/PlatformIcon.vue';
-import AccountLinkGuide from './dialogs/AccountLinkGuide.vue'
-import AccountSaolei from './accountlinks/AccountSaolei.vue';
-import AccountMsgames from './accountlinks/AccountMsgames.vue';
-import AccountWoM from './accountlinks/AccountWoM.vue';
+const AccountLinkGuide = () => import('./dialogs/AccountLinkGuide.vue')
+const AccountSaolei = () => import('./accountlinks/AccountSaolei.vue');
+const AccountMsgames = () => import('./accountlinks/AccountMsgames.vue');
+const AccountWoM = () => import('./accountlinks/AccountWoM.vue');
 import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 

--- a/front_end/src/utils/fileIO.ts
+++ b/front_end/src/utils/fileIO.ts
@@ -5,7 +5,6 @@
 
 import { UploadRawFile } from "element-plus";
 import { AvfVideo, EvfVideo } from "ms-toollib";
-import { MS_Level, MS_Levels } from "./ms_const";
 
 export function load_video_file(stream: Uint8Array, filename: string) {
     const ext = filename.slice(-3);

--- a/front_end/src/views/PlayerView.vue
+++ b/front_end/src/views/PlayerView.vue
@@ -74,12 +74,12 @@
 
 <script lang="ts" setup>
 // 我的地盘页面
-import { onMounted, ref, watch } from 'vue'
+import { defineAsyncComponent, onMounted, ref, watch } from 'vue'
 import useCurrentInstance from "@/utils/common/useCurrentInstance";
-import PlayerRecordView from '@/views/PlayerRecordView.vue';
-import PlayerVideosView from '@/views/PlayerVideosView.vue';
-import PlayerProfileView from './PlayerProfileView.vue';
-import UploadView from './UploadView.vue';
+const PlayerRecordView = defineAsyncComponent(() => import('@/views/PlayerRecordView.vue'));
+const PlayerVideosView = defineAsyncComponent(() => import('@/views/PlayerVideosView.vue'));
+const PlayerProfileView = defineAsyncComponent(() => import('@/views/PlayerProfileView.vue'));
+const UploadView = defineAsyncComponent(() => import('@/views/UploadView.vue'));
 // const AsyncPlayerVideosView = defineAsyncComponent(() => import('@/views/PlayerVideosView.vue'));
 import "../../node_modules/flag-icon-css/css/flag-icons.min.css";
 

--- a/front_end/vite.config.ts
+++ b/front_end/vite.config.ts
@@ -5,6 +5,7 @@ import vue from '@vitejs/plugin-vue'
 import wasm from "vite-plugin-wasm";
 // import vueDevTools from 'vite-plugin-vue-devtools'
 import topLevelAwait from "vite-plugin-top-level-await";
+import viteCompression from 'vite-plugin-compression';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -18,7 +19,12 @@ export default defineConfig(({ mode }) => {
       vue(),
       wasm(),
       //vueDevTools(),
-      topLevelAwait()
+      topLevelAwait(),
+      viteCompression({
+        algorithm: 'gzip', // Or 'brotliCompress' for Brotli compression
+        ext: '.gz', // Add a .gz extension to the compressed files
+        threshold: 1024, // Minimum file size in bytes to compress
+      }),
     ],
     resolve: {
       alias: {


### PR DESCRIPTION
- 个人主页的tab改用异步加载。#180 的改动取消了ms-toollib的异步引入，导致加载开销明显变大。此PR通过异步加载整个UploadView组件解决了这个问题。
- AccountLinkManager的子组件改用异步加载，未绑定账号的用户不会加载相应的子组件。
- vite打包使用gzip，使得加载内容减少了约三分之二