### PR TITLE
Feat/mine captcha

### DIFF
--- a/back_end/saolei/requirements.txt
+++ b/back_end/saolei/requirements.txt
@@ -7,7 +7,7 @@ django-model-utils==5.0.0
 django-ninja>=1.6.0
 django-ratelimit==4.1.0
 django-redis>=6.0.0
-django-simple-captcha>=0.5.18
+# django-simple-captcha>=0.5.18  # replaced by mine-sweeper captcha
 django-tasks-db>=0.12.0
 lxml>=6.0.2
 ms_toollib

--- a/back_end/saolei/saolei/settings.py
+++ b/back_end/saolei/saolei/settings.py
@@ -235,6 +235,12 @@ else:
     CSRF_COOKIE_SAMESITE = 'Lax'
     CSRF_COOKIE_SECURE = True     # https时候改成True
 
+    CORS_ALLOWED_ORIGINS = [
+        'https://strange-dust.github.io',
+    ]
+    # Optionally restrict to only the preview/download endpoints
+    CORS_URLS_REGEX = r'^/video/(preview|download)/.*$'
+    
 # 发送邮箱验证码
 EMAIL_HOST = 'smtp.88.com'     # 服务器
 EMAIL_PORT = 25                 # 一般情况下都为25

--- a/back_end/saolei/saolei/settings.py
+++ b/back_end/saolei/saolei/settings.py
@@ -235,12 +235,10 @@ else:
     CSRF_COOKIE_SAMESITE = 'Lax'
     CSRF_COOKIE_SECURE = True     # https时候改成True
 
-    CORS_ALLOWED_ORIGINS = [
-        'https://strange-dust.github.io',
-    ]
-    # Optionally restrict to only the preview/download endpoints
+    # allow CORS for the preview/download endpoints
+    CORS_ALLOW_ALL_ORIGINS = True
     CORS_URLS_REGEX = r'^/video/(preview|download)/.*$'
-    
+
 # 发送邮箱验证码
 EMAIL_HOST = 'smtp.88.com'     # 服务器
 EMAIL_PORT = 25                 # 一般情况下都为25

--- a/back_end/saolei/saolei/settings.py
+++ b/back_end/saolei/saolei/settings.py
@@ -41,7 +41,7 @@ ALLOWED_HOSTS = ['*']
 # Application definition
 
 INSTALLED_APPS = [
-    'captcha',
+    # 'captcha',  # replaced by mine-sweeper captcha
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/back_end/saolei/tests/test_mine_captcha.py
+++ b/back_end/saolei/tests/test_mine_captcha.py
@@ -1,0 +1,131 @@
+"""
+Tests for the mine-sweeper captcha (userprofile.utils.judge_captcha and
+userprofile.views.refresh_captcha).
+
+Uses django.test.TestCase to match the project's existing test style
+(see tests/test_dangerzone.py).
+"""
+from django.test import Client, TestCase
+from django_redis import get_redis_connection
+
+from userprofile.mine_captcha_puzzles import PUZZLES
+from userprofile.utils import judge_captcha
+
+
+REDIS_KEY_PREFIX = 'mine_captcha:'
+_WIDTH = 5  # bottom row size (matches PUZZLES today)
+
+
+def _set_puzzle(hashkey: str, puzzle_idx: int, ttl: int = 900) -> None:
+    conn = get_redis_connection('saolei_website')
+    conn.set(f'{REDIS_KEY_PREFIX}{hashkey}', str(puzzle_idx), ex=ttl)
+
+
+def _redis_has(hashkey: str) -> bool:
+    conn = get_redis_connection('saolei_website')
+    return conn.exists(f'{REDIS_KEY_PREFIX}{hashkey}') == 1
+
+
+def _safe_answer(puzzle_idx: int) -> str:
+    """Build the correct answer string (non-mine indices, sorted)."""
+    mines = set(PUZZLES[puzzle_idx][1])
+    safe = sorted(set(range(_WIDTH)) - mines)
+    return ','.join(str(i) for i in safe)
+
+
+class _RedisCleanupMixin:
+    """Wipe test_* keys before and after every test."""
+    def setUp(self):
+        super().setUp()
+        conn = get_redis_connection('saolei_website')
+        for key in conn.scan_iter(f'{REDIS_KEY_PREFIX}test_*'):
+            conn.delete(key)
+
+    def tearDown(self):
+        conn = get_redis_connection('saolei_website')
+        for key in conn.scan_iter(f'{REDIS_KEY_PREFIX}test_*'):
+            conn.delete(key)
+        super().tearDown()
+
+
+class JudgeCaptchaTests(_RedisCleanupMixin, TestCase):
+    # PUZZLES[0]: mines=[0,2,4]  ->  safe answer = "1,3"
+
+    def test_correct_answer_returns_true_and_deletes_key(self):
+        _set_puzzle('test_a', 0)
+        self.assertTrue(judge_captcha('1,3', 'test_a'))
+        self.assertFalse(_redis_has('test_a'))
+
+    def test_correct_answer_order_independent(self):
+        _set_puzzle('test_b', 0)
+        self.assertTrue(judge_captcha('3,1', 'test_b'))
+
+    def test_missing_one_returns_false_and_deletes_key(self):
+        _set_puzzle('test_c', 0)
+        self.assertFalse(judge_captcha('1', 'test_c'))
+        self.assertFalse(_redis_has('test_c'))
+
+    def test_extra_open_including_mine_returns_false(self):
+        _set_puzzle('test_d', 0)
+        # Opening a mine cell (0) plus the safe cells must fail.
+        self.assertFalse(judge_captcha('0,1,3', 'test_d'))
+
+    def test_unknown_hashkey_returns_false(self):
+        self.assertFalse(judge_captcha('1,3', 'test_does_not_exist'))
+
+    def test_empty_input_returns_false(self):
+        _set_puzzle('test_e', 0)
+        self.assertFalse(judge_captcha('', 'test_e'))
+
+    def test_dirty_input_returns_false_without_exception(self):
+        _set_puzzle('test_f', 0)
+        # Non-numeric token must NOT raise; it must be rejected.
+        self.assertFalse(judge_captcha('1,abc,3', 'test_f'))
+
+    def test_out_of_range_returns_false(self):
+        _set_puzzle('test_g', 0)
+        self.assertFalse(judge_captcha('1,5', 'test_g'))
+
+    def test_negative_index_returns_false(self):
+        _set_puzzle('test_h', 0)
+        self.assertFalse(judge_captcha('-1,1,3', 'test_h'))
+
+    def test_all_puzzles_have_correct_safe_answer(self):
+        for idx in range(len(PUZZLES)):
+            key = f'test_p{idx}'
+            _set_puzzle(key, idx)
+            self.assertTrue(
+                judge_captcha(_safe_answer(idx), key),
+                msg=f'puzzle {idx} safe answer failed',
+            )
+
+
+class RefreshCaptchaTests(_RedisCleanupMixin, TestCase):
+    def test_refresh_returns_hashkey_and_top(self):
+        resp = self.client.get('/userprofile/refresh_captcha/')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['status'], 100)
+        self.assertIn('hashkey', data)
+        self.assertGreater(len(data['hashkey']), 8)
+        self.assertIsInstance(data['top'], list)
+        self.assertEqual(len(data['top']), _WIDTH)
+
+        # The redis key exists with TTL close to 900s
+        conn = get_redis_connection('saolei_website')
+        ttl = conn.ttl(f"{REDIS_KEY_PREFIX}{data['hashkey']}")
+        self.assertGreater(ttl, 800)
+        self.assertLessEqual(ttl, 900)
+
+        # Cleanup (TTL pattern: hashkey is a uuid, not test_*, so clean explicitly)
+        conn.delete(f"{REDIS_KEY_PREFIX}{data['hashkey']}")
+
+    def test_returned_top_matches_a_known_puzzle(self):
+        resp = self.client.get('/userprofile/refresh_captcha/')
+        top = tuple(resp.json()['top'])
+        known = {tuple(p[0]) for p in PUZZLES}
+        self.assertIn(top, known)
+
+        # Cleanup
+        conn = get_redis_connection('saolei_website')
+        conn.delete(f"{REDIS_KEY_PREFIX}{resp.json()['hashkey']}")

--- a/back_end/saolei/userprofile/management/commands/runapscheduleruserprofile.py
+++ b/back_end/saolei/userprofile/management/commands/runapscheduleruserprofile.py
@@ -2,7 +2,7 @@ import logging
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
-from captcha.models import CaptchaStore
+# from captcha.models import CaptchaStore  # replaced by mine-sweeper captcha (Redis TTL handles expiry)
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import timezone
@@ -26,11 +26,11 @@ def delete_overdue_emailverifyrecord():
     EmailVerifyRecord.objects.filter(send_time__lt=start).delete()
 
 
-@util.close_old_connections
-def delete_overdue_captcha():
-    # 定时清除过期图形验证码（15分钟过期）
-    # start = timezone.now() - timezone.timedelta(seconds=900)
-    CaptchaStore.objects.filter(expiration__lt=timezone.now()).delete()
+# @util.close_old_connections
+# def delete_overdue_captcha():
+#     # 定时清除过期图形验证码（15分钟过期）
+#     CaptchaStore.objects.filter(expiration__lt=timezone.now()).delete()
+# Replaced by mine-sweeper captcha; Redis TTL auto-expires keys.
 
 
 # The `close_old_connections` decorator ensures that database connections, that have become
@@ -68,17 +68,18 @@ class Command(BaseCommand):
         )
         logger.info("Added job 'delete_overdue_emailverifyrecord'.")
 
-        scheduler.add_job(
-            delete_overdue_captcha,
-            trigger=CronTrigger(
-                day_of_week='mon', hour='01', minute='05',
-            ),
-            id='delete_overdue_captcha',  # The `id` assigned to each job MUST be unique
-            misfire_grace_time=30,
-            max_instances=1,
-            replace_existing=True,
-        )
-        logger.info("Added job 'delete_overdue_captcha'.")
+        # scheduler.add_job(
+        #     delete_overdue_captcha,
+        #     trigger=CronTrigger(
+        #         day_of_week='mon', hour='01', minute='05',
+        #     ),
+        #     id='delete_overdue_captcha',
+        #     misfire_grace_time=30,
+        #     max_instances=1,
+        #     replace_existing=True,
+        # )
+        # logger.info("Added job 'delete_overdue_captcha'.")
+        # Replaced by mine-sweeper captcha; Redis TTL handles expiry.
 
         scheduler.add_job(
             delete_old_job_executions,

--- a/back_end/saolei/userprofile/mine_captcha_puzzles.py
+++ b/back_end/saolei/userprofile/mine_captcha_puzzles.py
@@ -1,0 +1,19 @@
+"""
+Mine-sweeper captcha puzzle bank.
+
+Each puzzle:
+- top: 5 integers shown on the top row (numbers indicate count of adjacent
+  mines using standard minesweeper 8-direction adjacency).
+- mines: 0-based indices of cells in the bottom row that are mines.
+
+The expected captcha answer is the complement set (non-mine indices); the
+user must click open every non-mine cell to pass.
+
+All three initial puzzles have a unique solution under the 8-direction rule.
+"""
+
+PUZZLES: list[tuple[list[int], list[int]]] = [
+    ([1, 2, 1, 2, 1], [0, 2, 4]),   # M _ M _ M     safe = {1, 3}
+    ([1, 2, 3, 2, 1], [1, 2, 3]),   # _ M M M _     safe = {0, 4}
+    ([1, 1, 2, 1, 1], [1, 3]),      # _ M _ M _     safe = {0, 2, 4}
+]

--- a/back_end/saolei/userprofile/urls.py
+++ b/back_end/saolei/userprofile/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     path('set_staff/', views.set_staff, name='set_staff'),
     path('del_user_info/', views.del_user_info, name='del_user_info'),
     # path('delete/<int:id>/', views.user_delete, name='delete'),
-    path('captcha/', include('captcha.urls')),
+    # path('captcha/', include('captcha.urls')),  # replaced by mine-sweeper captcha
     path('refresh_captcha/', views.refresh_captcha),
     path('get_email_captcha/', views.get_email_captcha),
     path('get/', views.get_userProfile),

--- a/back_end/saolei/userprofile/utils.py
+++ b/back_end/saolei/userprofile/utils.py
@@ -3,28 +3,61 @@ import os
 import urllib.parse
 import uuid
 
-from captcha.models import CaptchaStore
+# from captcha.models import CaptchaStore  # replaced by mine-sweeper captcha
 from django.conf import settings
 from django.core.mail import send_mail
 from django.utils import timezone
+from django_redis import get_redis_connection
 
 from utils import generate_code
 from videomanager.models import VideoModel
+from .mine_captcha_puzzles import PUZZLES
 from .models import EmailVerifyRecord, UserProfile
 
 
-# 验证验证码
-def judge_captcha(captchaStr: str, captchaHashkey):
-    if captchaStr and captchaHashkey:
-        get_captcha = CaptchaStore.objects.filter(
-            hashkey=captchaHashkey).first()
-        if get_captcha and get_captcha.response == captchaStr.lower():
-            # 图形验证码15分钟有效，get_captcha.expiration是过期时间
-            if (get_captcha.expiration - timezone.now()).seconds >= 0:
-                CaptchaStore.objects.filter(hashkey=captchaHashkey).delete()
-                return True
-    CaptchaStore.objects.filter(hashkey=captchaHashkey).delete()
-    return False
+_MINE_CAPTCHA_REDIS_PREFIX = 'mine_captcha:'
+_MINE_CAPTCHA_BOTTOM_WIDTH = 5
+
+
+def judge_captcha(captchaStr: str, captchaHashkey: str) -> bool:
+    """
+    Validate a mine-sweeper captcha submission.
+
+    captchaStr: comma-separated 0-based indices of cells the user OPENED
+                (i.e. believed to be safe / non-mines), e.g. "1,3".
+                Order does not matter.
+    captchaHashkey: the hashkey returned by refresh_captcha.
+
+    Returns True iff the opened set exactly equals the puzzle's non-mine set
+    (every safe cell opened, no mine cell opened). Deletes the redis key in
+    all cases (one-shot, error-once-rotate-puzzle).
+    """
+    if not captchaStr or not captchaHashkey:
+        return False
+
+    conn = get_redis_connection('saolei_website')
+    redis_key = f'{_MINE_CAPTCHA_REDIS_PREFIX}{captchaHashkey}'
+    raw = conn.get(redis_key)
+    if raw is None:
+        return False
+    conn.delete(redis_key)  # one-shot regardless of outcome
+
+    try:
+        puzzle_idx = int(raw)
+        opened = {int(s) for s in captchaStr.split(',') if s.strip() != ''}
+    except (ValueError, TypeError):
+        return False
+
+    if not opened:
+        return False
+    if any(i < 0 or i >= _MINE_CAPTCHA_BOTTOM_WIDTH for i in opened):
+        return False
+    if puzzle_idx < 0 or puzzle_idx >= len(PUZZLES):
+        return False
+
+    _, mine_positions = PUZZLES[puzzle_idx]
+    safe_positions = set(range(_MINE_CAPTCHA_BOTTOM_WIDTH)) - set(mine_positions)
+    return opened == safe_positions
 
 
 # 发送邮件，根据send_type不同发送不同的邮件内容

--- a/back_end/saolei/userprofile/views.py
+++ b/back_end/saolei/userprofile/views.py
@@ -1,17 +1,21 @@
 import json
 import logging
 import os
+import random
+import uuid
 
-from captcha.models import CaptchaStore
+# from captcha.models import CaptchaStore  # replaced by mine-sweeper captcha
 from django.conf import settings
 from django.contrib.auth import authenticate, login, logout
 from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, HttpResponseNotFound, JsonResponse
 from django.views.decorators.http import require_GET, require_POST
 from django_ratelimit.decorators import ratelimit
+from django_redis import get_redis_connection
 
 from msuser.models import UserMS
 from .decorators import staff_required
 from .forms import EmailForm, UserLoginForm, UserRegisterForm, UserRetrieveForm
+from .mine_captcha_puzzles import PUZZLES
 from .models import EmailVerifyRecord, UserProfile
 from .utils import judge_captcha, judge_email_verification, send_email, user_metadata
 
@@ -175,25 +179,32 @@ def del_user_info(request):
     user.avatar = None
 
 
-# 创建验证码
+_MINE_CAPTCHA_REDIS_PREFIX = 'mine_captcha:'
+_MINE_CAPTCHA_TTL_SECONDS = 900
+
+
+def _new_mine_captcha() -> dict:
+    """Pick a puzzle (PUZZLES[0] in E2E mode, random otherwise), persist to Redis,
+    return the public payload (hashkey + top-row numbers)."""
+    puzzle_idx = 0 if settings.E2E_TEST else random.randrange(len(PUZZLES))
+    hashkey = str(uuid.uuid4())
+    conn = get_redis_connection('saolei_website')
+    conn.set(
+        f'{_MINE_CAPTCHA_REDIS_PREFIX}{hashkey}',
+        str(puzzle_idx),
+        ex=_MINE_CAPTCHA_TTL_SECONDS,
+    )
+    top, _ = PUZZLES[puzzle_idx]
+    return {'hashkey': hashkey, 'top': list(top)}
+
+
+# 刷新验证码（判雷题）
 @ratelimit(key='ip', rate='60/h')
-def captcha(request):
-    if settings.E2E_TEST:
-        # Create a fixed captcha for E2E tests
-        captcha_obj = CaptchaStore.objects.create(challenge='test', response='test')
-        hashkey = captcha_obj.hashkey
-    else:
-        hashkey = CaptchaStore.generate_key()
-
-    return {'hashkey': hashkey}
-
-
-# 刷新验证码
-@ratelimit(key='ip', rate='60/h')
+@require_GET
 def refresh_captcha(request):
-    c = captcha(request)
-    c.update({'status': 100})
-    return HttpResponse(json.dumps(c), content_type='application/json')
+    payload = _new_mine_captcha()
+    payload['status'] = 100
+    return JsonResponse(payload)
 
 
 # 验证验证码，若通过，发送email

--- a/front_end/cypress/e2e/account.cy.ts
+++ b/front_end/cypress/e2e/account.cy.ts
@@ -47,7 +47,7 @@ describe('User Authentication', () => {
         // 填写注册信息
         cy.contains('用户名').next().find('input').type('testUser');
         cy.contains('邮箱').next().find('input').type('testUser@example.com');
-        cy.contains('图形验证码').next().find('input').type('test');
+        cy.solveMineCaptcha();
         cy.contains('发送').click();
         cy.contains('邮件发送成功');
         cy.closeElNotifications();
@@ -77,7 +77,7 @@ describe('User Authentication', () => {
         // 填写登录信息
         cy.contains('用户名').next().find('input').type('testUser');
         cy.contains('密码').next().find('input').type('testPassword');
-        cy.contains('验证码').next().find('input').type('test');
+        cy.solveMineCaptcha();
 
         // 完成登录
         cy.contains('用户登录').parent().parent().find('button').contains('登录').click();
@@ -97,7 +97,7 @@ describe('User Authentication', () => {
         cy.contains('登录').click();
         cy.contains('用户名').next().find('input').type('testUser');
         cy.contains('密码').next().find('input').type('testPassword');
-        cy.contains('验证码').next().find('input').type('test');
+        cy.solveMineCaptcha();
         cy.contains('记住我').click();
         cy.contains('用户登录').parent().parent().find('button').contains('登录').click();
         cy.contains('用户登录').should('not.exist');
@@ -121,7 +121,7 @@ describe('User Authentication', () => {
         cy.contains('登录').click();
         cy.contains('用户名').next().find('input').type('testUser');
         cy.contains('密码').next().find('input').type('newPassword');
-        cy.contains('验证码').next().find('input').type('test');
+        cy.solveMineCaptcha();
         cy.contains('用户登录').parent().parent().find('button').contains('登录').click();
         cy.contains('用户名或密码不正确');
         expectNotLoggedIn();
@@ -133,7 +133,7 @@ describe('User Authentication', () => {
 
         // 填写找回密码信息
         cy.contains('邮箱').next().find('input').type('testUser@example.com');
-        cy.contains('图形验证码').next().find('input').type('test');
+        cy.solveMineCaptcha();
         cy.contains('发送').click();
         cy.contains('邮件发送成功');
         cy.closeElNotifications();

--- a/front_end/cypress/support/commands.ts
+++ b/front_end/cypress/support/commands.ts
@@ -38,6 +38,12 @@ declare global {
             mockCaptchaRefresh(options?: any): void;
 
             /**
+             * 解判雷题验证码（E2E 模式下固定为 PUZZLES[0]，正确答案：点开 [1, 3]）
+             * @example cy.solveMineCaptcha()
+             */
+            solveMineCaptcha(): Chainable<void>;
+
+            /**
              * 模拟获取邮件验证码
              * @param options - 请求选项
              * @example cy.mockGetEmailCode({})
@@ -90,13 +96,18 @@ Cypress.Commands.add('mockCaptchaRefresh', (options) => {
             body: {
                 status: 100,
                 hashkey: `testkey${captchaRefreshCount}`,
+                top: [1, 2, 1, 2, 1],  // mine-captcha puzzle: PUZZLES[0]
             },
             ...options,
         });
     }).as('captchaRefresh');
-    cy.intercept('GET', '/userprofile/captcha/image/**', {
-        fixture: 'test.png',
-    }).as('testImage');
+});
+
+// E2E mode pins PUZZLES[0] (top=[1,2,1,2,1], mines=[0,2,4]).
+// Correct answer = open all non-mine cells = [1, 3].
+Cypress.Commands.add('solveMineCaptcha', () => {
+    cy.get('[data-cy=mine-cell-1]').click();
+    cy.get('[data-cy=mine-cell-3]').click();
 });
 
 Cypress.Commands.add('mockGetEmailCode', (options) => {
@@ -136,7 +147,8 @@ Cypress.Commands.add('mockLogin', () => {
         const username = params.get('username');
         const password = params.get('password');
         const captcha = params.get('captcha');
-        if (captcha !== 'test') {
+        // Mine-captcha PUZZLES[0]: correct answer = opened set {1, 3} -> "1,3"
+        if (captcha !== '1,3') {
             req.reply({
                 'type': 'error',
                 'object': 'login',

--- a/front_end/src/components/MineCaptcha.cy.ts
+++ b/front_end/src/components/MineCaptcha.cy.ts
@@ -1,0 +1,62 @@
+import MineCaptcha from './MineCaptcha.vue';
+
+import $axios from '@/http';
+import i18n from '@/i18n';
+
+const mountOptions = {
+    global: {
+        plugins: [i18n],
+        config: {
+            globalProperties: {
+                $axios,
+            },
+        },
+    },
+};
+
+describe('<MineCaptcha />', () => {
+    beforeEach(() => {
+        cy.intercept('GET', '/userprofile/refresh_captcha/', {
+            statusCode: 200,
+            body: { status: 100, hashkey: 'test-key', top: [1, 2, 1, 2, 1] },
+        }).as('refresh');
+    });
+
+    it('renders 5 number cells and 5 clickable cells', () => {
+        cy.mount(MineCaptcha, mountOptions);
+        cy.wait('@refresh');
+        // top numbers: 5 .revealed; bottom: 5 .unrevealed initially
+        cy.get('.cell.revealed').should('have.length', 5);
+        cy.get('.cell.unrevealed').should('have.length', 5);
+    });
+
+    it('toggles opened state on bottom-cell click', () => {
+        cy.mount(MineCaptcha, mountOptions);
+        cy.wait('@refresh');
+        cy.get('[data-cy=mine-cell-0]').click();
+        cy.get('[data-cy=mine-cell-0]').should('have.class', 'opened');
+        cy.get('[data-cy=mine-cell-0]').click();
+        cy.get('[data-cy=mine-cell-0]').should('not.have.class', 'opened');
+    });
+
+    it('top number cells do not toggle', () => {
+        cy.mount(MineCaptcha, mountOptions);
+        cy.wait('@refresh');
+        // First .revealed is a top-row number cell, not a bottom cell.
+        cy.get('.cell.revealed').first().click({ force: true });
+        cy.get('.cell.revealed').first().should('not.have.class', 'opened');
+    });
+
+    it('getResponse() returns sorted comma-separated indices', () => {
+        cy.mount(MineCaptcha, mountOptions).then(({ wrapper }) => {
+            cy.wait('@refresh').then(() => {
+                cy.get('[data-cy=mine-cell-3]').click();
+                cy.get('[data-cy=mine-cell-1]').click();
+                cy.wrap(null).then(() => {
+                    // @ts-expect-error vm typing
+                    expect(wrapper.vm.getResponse()).to.equal('1,3');
+                });
+            });
+        });
+    });
+});

--- a/front_end/src/components/MineCaptcha.vue
+++ b/front_end/src/components/MineCaptcha.vue
@@ -1,0 +1,153 @@
+<template>
+    <div class="mine-captcha">
+        <div class="hint">{{ t('form.openAllSafe') }}</div>
+        <div v-if="loading" class="loading">{{ t('form.captchaLoading') }}</div>
+        <div v-else-if="loadFailed" class="loading">{{ t('form.captchaLoadingFail') }}</div>
+        <div v-else class="grid" :style="{ gridTemplateColumns: `repeat(${width}, 28px)` }">
+            <!-- top row: numbers -->
+            <div
+                v-for="(n, i) in top" :key="`top-${i}`"
+                class="cell revealed"
+                :class="`num-${n}`"
+            >
+                {{ n }}
+            </div>
+            <!-- bottom row: clickable -->
+            <div
+                v-for="i in width" :key="`bot-${i - 1}`"
+                class="cell"
+                :class="opened.has(i - 1) ? 'revealed opened' : 'unrevealed'"
+                :data-cy="`mine-cell-${i - 1}`"
+                @click="toggleOpen(i - 1)"
+            />
+        </div>
+        <button type="button" class="refresh-btn" @click="refreshPic">🔄</button>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { httpErrorNotification, unknownErrorNotification } from './Notifications';
+
+import useCurrentInstance from '@/utils/common/useCurrentInstance';
+
+const { proxy } = useCurrentInstance();
+const { t } = useI18n();
+
+const hashkey = ref('');
+const top = ref<number[]>([]);
+const width = ref(5);
+const opened = ref<Set<number>>(new Set());
+const loading = ref(true);
+const loadFailed = ref(false);
+
+const refreshPic = () => {
+    loading.value = true;
+    loadFailed.value = false;
+    opened.value = new Set();
+    proxy.$axios.get('/userprofile/refresh_captcha/').then((response) => {
+        if (response.data.status === 100) {
+            hashkey.value = response.data.hashkey;
+            top.value = response.data.top;
+            width.value = response.data.top.length;
+        } else {
+            unknownErrorNotification(response.data);
+            loadFailed.value = true;
+        }
+        loading.value = false;
+    }).catch((error) => {
+        httpErrorNotification(error);
+        loadFailed.value = true;
+        loading.value = false;
+    });
+};
+
+const toggleOpen = (idx: number) => {
+    const next = new Set(opened.value);
+    if (next.has(idx)) next.delete(idx);
+    else next.add(idx);
+    opened.value = next;
+};
+
+const getResponse = (): string => {
+    return [...opened.value].sort((a, b) => a - b).join(',');
+};
+
+const openedCount = () => opened.value.size;
+
+onMounted(refreshPic);
+
+defineExpose({
+    hashkey,
+    refreshPic,
+    getResponse,
+    openedCount,
+});
+</script>
+
+<style scoped>
+.mine-captcha {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 4px;
+    align-items: flex-start;
+}
+.hint {
+    font-size: 12px;
+    color: #606266;
+}
+.loading {
+    height: 64px;
+    line-height: 64px;
+    color: #909399;
+}
+.grid {
+    display: grid;
+    grid-auto-rows: 28px;
+    gap: 2px;
+}
+.cell {
+    width: 28px;
+    height: 28px;
+    text-align: center;
+    line-height: 28px;
+    font-weight: bold;
+    font-family: monospace;
+    user-select: none;
+}
+.cell.revealed {
+    background: #c0c0c0;
+    border: 1px solid #808080;
+}
+.cell.unrevealed {
+    background: #bdbdbd;
+    border-top: 2px solid #ffffff;
+    border-left: 2px solid #ffffff;
+    border-right: 2px solid #7b7b7b;
+    border-bottom: 2px solid #7b7b7b;
+    cursor: pointer;
+}
+.cell.unrevealed:hover {
+    background: #d4d4d4;
+}
+.cell.revealed.opened {
+    background: #d4d4d4;
+    cursor: pointer;
+}
+.num-1 { color: #0000ff; }
+.num-2 { color: #008000; }
+.num-3 { color: #ff0000; }
+.num-4 { color: #000080; }
+.num-5 { color: #800000; }
+.num-6 { color: #008080; }
+.refresh-btn {
+    align-self: flex-end;
+    background: none;
+    border: 1px solid #dcdfe6;
+    border-radius: 4px;
+    cursor: pointer;
+    padding: 2px 6px;
+}
+</style>

--- a/front_end/src/components/dialogs/LoginDialog.vue
+++ b/front_end/src/components/dialogs/LoginDialog.vue
@@ -12,13 +12,9 @@
             <el-form-item prop="password" :label="t('form.password')" :error="passwordError">
                 <el-input v-model="loginForm.password" maxlength="20" show-password prefix-icon="Lock" />
             </el-form-item>
-            <!-- 验证码 -->
-            <el-form-item prop="captcha" :label="t('form.captcha')" :error="captchaError">
-                <div style="display: flex;">
-                    <el-input v-model.trim="loginForm.captcha" prefix-icon="Key" class="code" maxlength="4" />
-                    &nbsp;
-                    <ValidCode ref="refValidCode" />
-                </div>
+            <!-- 验证码（判雷题） -->
+            <el-form-item :label="t('form.captcha')" :error="captchaError">
+                <MineCaptcha ref="refMineCaptcha" />
             </el-form-item>
             <!-- 记住我 -->
             <el-form-item>
@@ -49,7 +45,7 @@ import { reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { httpErrorNotification } from '@/components/Notifications';
-import ValidCode from '@/components/ValidCode.vue';
+import MineCaptcha from '@/components/MineCaptcha.vue';
 import useCurrentInstance from '@/utils/common/useCurrentInstance';
 
 const visible = defineModel({ type: Boolean, default: false });
@@ -58,7 +54,7 @@ const emit = defineEmits(['forgetPassword', 'login']);
 const { t } = useI18n();
 const { proxy } = useCurrentInstance();
 
-const refValidCode = ref<typeof ValidCode>();
+const refMineCaptcha = ref<typeof MineCaptcha>();
 const remember_me = ref(false);
 const captchaError = ref('');
 const passwordError = ref('');
@@ -66,13 +62,11 @@ const passwordError = ref('');
 interface LoginForm {
     username: string;
     password: string;
-    captcha: string;
 }
 
 const loginForm = reactive<LoginForm>({
     username: '',
     password: '',
-    captcha: '',
 });
 
 const ruleFormRef = ref<FormInstance>();
@@ -80,7 +74,6 @@ const ruleFormRef = ref<FormInstance>();
 const rules = reactive<FormRules<LoginForm>>({
     username: [{ required: true, message: t('msg.usernameRequired') }],
     password: [{ required: true, message: t('msg.passwordRequired') }],
-    captcha: [{ required: true, message: t('msg.captchaRequired') }],
 });
 
 const submitForm = async (formEl: FormInstance | undefined) => {
@@ -92,8 +85,8 @@ const submitForm = async (formEl: FormInstance | undefined) => {
             user_id: user_id, // 为空时post会自动忽略该项
             username: loginForm.username,
             password: loginForm.password,
-            captcha: loginForm.captcha,
-            hashkey: refValidCode.value?.hashkey,
+            captcha: refMineCaptcha.value?.getResponse(),
+            hashkey: refMineCaptcha.value?.hashkey,
         }).then(function (response) {
             const data = response.data;
             if (data.type == 'success') {
@@ -102,10 +95,9 @@ const submitForm = async (formEl: FormInstance | undefined) => {
                 if (data.category == 'captcha') {
                     captchaError.value = t('msg.captchaFail');
                 } else if (data.category == 'password') {
-                    loginForm.captcha = '';
                     passwordError.value = t('msg.usernamePasswordInvalid');
                 }
-                if (refValidCode.value !== undefined) refValidCode.value.refreshPic();
+                if (refMineCaptcha.value !== undefined) refMineCaptcha.value.refreshPic();
             }
         }).catch(httpErrorNotification);
     });

--- a/front_end/src/components/formItems/emailCodeBlock.vue
+++ b/front_end/src/components/formItems/emailCodeBlock.vue
@@ -1,29 +1,22 @@
 <!--
 邮箱验证码表单项
-发送验证码的前置条件：填写了有效邮箱，且通过了图形验证
+发送验证码的前置条件：填写了有效邮箱，且通过了判雷题验证
 -->
 <template>
-    <!-- 图形验证码 -->
+    <!-- 验证码（判雷题） -->
     <el-form-item ref="captchaFormRef" :disabled="!email_success" :label="t('form.imageCaptcha')">
-        <div style="display: flex">
-            <el-input
-                v-model.trim="captcha" prefix-icon="Key" class="code" maxlength="4"
-                @input="captchaHandler"
-            />
-            &nbsp;
-            <ValidCode ref="refValidCode" />
-        </div>
+        <MineCaptcha ref="refMineCaptcha" />
     </el-form-item>
     <!-- 邮箱验证码 -->
     <el-form-item ref="emailCodeFormRef" prop="emailCode" :label="t('form.emailCode')">
         <div style="display: flex">
             <el-input
                 v-model.trim="emailCode" data-cy="emailCode"
-                prefix-icon="Key" maxlength="6" :disabled="captcha.length!=4" :placeholder="t(email_code_placeholder)"
+                prefix-icon="Key" maxlength="6" :disabled="(refMineCaptcha?.openedCount() ?? 0) === 0" :placeholder="t(email_code_placeholder)"
                 @input="emailCodeHandler"
             />
             &nbsp;
-            <el-button :disabled="captcha.length != 4 || counting" @click="getEmailCaptcha(type)">
+            <el-button :disabled="(refMineCaptcha?.openedCount() ?? 0) === 0 || counting" @click="getEmailCaptcha(type)">
                 <vue-countdown v-if="counting" v-slot="{ totalSeconds }" :time="60000" @end="counting = false;">
                     ({{ totalSeconds }})
                 </vue-countdown>
@@ -39,7 +32,7 @@ import { ElButton, ElFormItem, ElInput, ElNotification } from 'element-plus';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import ValidCode from '../ValidCode.vue';
+import MineCaptcha from '../MineCaptcha.vue';
 
 import { local } from '@/store';
 import { validateError, validateSuccess } from '@/utils/common/elFormValidate';
@@ -64,13 +57,12 @@ const emailCode = defineModel({ type: String, required: true });
 const { proxy } = useCurrentInstance();
 const { t } = useI18n();
 
-const captcha = ref(''); // 图形验证码
 const hashkey = ref(''); // 邮箱验证码hash
 const email_success = ref(false); // 邮件发送成功
 const email_handling = ref(false); // 正在校验图形验证码与发送邮件
 const counting = ref(false);
 
-const refValidCode = ref<typeof ValidCode>();
+const refMineCaptcha = ref<typeof MineCaptcha>();
 const captchaFormRef = ref<typeof ElFormItem>();
 const emailCodeFormRef = ref<typeof ElFormItem>();
 
@@ -92,11 +84,6 @@ const email_code_placeholder = computed(() => {
     else return '';
 });
 
-const captchaHandler = (value: string) => {
-    if (value.length == 0) validateError(captchaFormRef, t('msg.captchaRequired'));
-    else validateSuccess(captchaFormRef);
-};
-
 const emailCodeHandler = (value: string) => {
     if (value.length == 0) validateError(emailCodeFormRef, t('msg.emailCodeRequired'));
     else validateSuccess(emailCodeFormRef);
@@ -113,8 +100,8 @@ const getEmailCaptcha = (type: string) => {
     email_handling.value = true;
     counting.value = true;
     proxy.$axios.post('/userprofile/get_email_captcha/', {
-        captcha: captcha.value,
-        hashkey: refValidCode.value!.hashkey,
+        captcha: refMineCaptcha.value?.getResponse(),
+        hashkey: refMineCaptcha.value?.hashkey,
         email: prop.email,
         type: type,
     }).then(function (response) {
@@ -149,8 +136,7 @@ const getEmailCaptcha = (type: string) => {
 };
 
 const refreshCaptcha = () => {
-    refValidCode.value!.refreshPic();
-    captcha.value = '';
+    refMineCaptcha.value!.refreshPic();
 };
 
 </script>

--- a/front_end/src/i18n/locales/de.ts
+++ b/front_end/src/i18n/locales/de.ts
@@ -6,6 +6,7 @@ export default {
         confirmPassword: 'Passwort bestätigen',
         email: 'E-Mail',
         emailCode: 'E-Mail Code',
+        openAllSafe: 'Öffne alle sicheren Felder',
         password: 'Passwort',
         username: 'Benutzername',
     },

--- a/front_end/src/i18n/locales/en.ts
+++ b/front_end/src/i18n/locales/en.ts
@@ -206,6 +206,7 @@ export default {
         email: 'Email',
         emailCode: 'Email code',
         imageCaptcha: 'Image captcha',
+        openAllSafe: 'Open all safe cells',
         password: 'Password',
         username: 'Username',
     },

--- a/front_end/src/i18n/locales/pl.ts
+++ b/front_end/src/i18n/locales/pl.ts
@@ -22,6 +22,7 @@ export default {
         confirmPassword: 'potwierdź hasło',
         email: 'email',
         emailCode: 'hasło pojedyńczego użytku',
+        openAllSafe: 'Otwórz wszystkie bezpieczne pola',
         password: 'hasło',
         username: 'nazwa użytkownika',
     },

--- a/front_end/src/i18n/locales/zh-cn.ts
+++ b/front_end/src/i18n/locales/zh-cn.ts
@@ -204,6 +204,7 @@ export default {
         email: '邮箱',
         emailCode: '邮箱验证码',
         imageCaptcha: '图形验证码',
+        openAllSafe: '请点开所有非雷格',
         password: '密码',
         username: '用户名',
     },


### PR DESCRIPTION
- 后端：`CaptchaStore(challenge, response)`，15 分钟过期。`judge_captcha(captchaStr, hashkey)` 校验，校验后删除记录。
- 前端：`ValidCode.vue` 拉图，用户在外层输入框填写文字。
- 调用点：`user_login`（登录）、`get_email_captcha`（注册/找回密码发送邮件前的图形码校验）。

将其替换为与"开源扫雷网"主题契合的 **判雷题**：

- 2×5 网格，上排显示数字提示，下排是 5 个未揭开的格子
- 用户必须正确**点开所有非雷格**（即完全避开所有雷）才算通过
- 错一次立即换题（hashkey 失效）
- 题库（Python 常量）
- （后期可以Django Admin + 数据库）
`back_end/saolei/userprofile/mine_captcha_puzzles.py`