### PR TITLE
Add bulk video info/detail APIs and CORS paths

### DIFF
--- a/back_end/saolei/saolei/settings.py
+++ b/back_end/saolei/saolei/settings.py
@@ -239,12 +239,18 @@ else:
 
     # allow CORS for public video and user profile endpoints
     CORS_ALLOW_ALL_ORIGINS = True
-    CORS_URLS_REGEX = (
-        r'^/('
-        r'video/(preview|download)/.*'
-        r'|api/userprofile/(videolist/?|info/.*|identifier/?|avatar/.*)'
-        r')$'
-    )
+    CORS_PATHS = [
+        r'video/(preview|download)/.*',
+        r'api/userprofile/avatar/.*',
+        r'api/userprofile/identifier/?',
+        r'api/userprofile/info/.*',
+        r'api/userprofile/infobulk/?',
+        r'api/userprofile/infoupdated/?',
+        r'api/userprofile/videolist/?',
+        r'api/video/infobulk/?',
+        r'api/video/detailbulk/?',
+    ]
+    CORS_URLS_REGEX = rf'^/({"|".join(CORS_PATHS)})$'
 
 # 发送邮箱验证码
 EMAIL_HOST = 'smtp.88.com'     # 服务器

--- a/back_end/saolei/videomanager/api.py
+++ b/back_end/saolei/videomanager/api.py
@@ -30,7 +30,9 @@ VideoFullOut = create_schema(
         'left', 'right', 'double', 'cl',
         'left_ce', 'right_ce', 'double_ce', 'ce',
         'cell0', 'cell1', 'cell2', 'cell3', 'cell4', 'cell5', 'cell6', 'cell7', 'cell8',
-        'video__identifier',
+    ],
+    custom_fields=[
+        ('video__identifier', str, ''),
     ],
 )
 

--- a/back_end/saolei/videomanager/api.py
+++ b/back_end/saolei/videomanager/api.py
@@ -15,7 +15,22 @@ VideoBaseOut = create_schema(
         'id', 'player',
         'software', 'level', 'mode', 'state',
         'cl', 'ce', 'timems', 'bv',
-        'upload_time', 'ongoing_tournament',
+        'upload_time', 'end_time',
+    ],
+)
+
+
+VideoFullOut = create_schema(
+    VideoModel,
+    fields=[
+        'id', 'player',
+        'software', 'level', 'mode', 'state',
+        'timems', 'bv', 'path', 'flag', 'op', 'isl',
+        'upload_time', 'end_time', 'file_size',
+        'left', 'right', 'double', 'cl',
+        'left_ce', 'right_ce', 'double_ce', 'ce',
+        'cell0', 'cell1', 'cell2', 'cell3', 'cell4', 'cell5', 'cell6', 'cell7', 'cell8',
+        'video__identifier',
     ],
 )
 
@@ -31,3 +46,31 @@ def get_review_queue(request):
         videos = videos.filter(ongoing_tournament=False)
 
     return videos
+
+
+@router.get('/infobulk', response=list[VideoBaseOut])
+@decorate_view(ratelimit(key='ip', rate='1/s'))
+def get_video_info_bulk(request, first: int, count: int):
+    """
+    - ratelimit(key='ip', rate='1/s')
+
+    Video id from `first` to `first + count - 1`. Hidden videos are skipped. Count is capped at 5000.
+    """
+    first = max(1, first)
+    count = max(1, min(5000, count))
+
+    return VideoModel.objects.filter(id_gte=first, id_lt=first + count, ongoing_tournament=False)
+
+
+@router.get('/detailbulk', response=list[VideoFullOut])
+@decorate_view(ratelimit(key='ip', rate='1/s'))
+def get_video_detail_bulk(request, first: int, count: int):
+    """
+    - ratelimit(key='ip', rate='1/s')
+
+    Video id from `first` to `first + count - 1`. Hidden videos are skipped. Count is capped at 1000.
+    """
+    first = max(1, first)
+    count = max(1, min(1000, count))
+
+    return VideoModel.objects.filter(id_gte=first, id_lt=first + count, ongoing_tournament=False)


### PR DESCRIPTION
- Expose new public CORS paths and add bulk video endpoints.
- Introduces `CORS_PATHS` and builds `CORS_URLS_REGEX` from it to allow CORS for additional video and userprofile routes.
- Updates `VideoBaseOut` (replaces `ongoing_tournament` with `end_time`) and adds a richer `VideoFullOut` schema.
- Adds two rate-limited endpoints: `GET /api/video/infobulk` (returns `VideoBaseOut` list; id range `first..first+count-1`; `count` capped at 5000) and `GET /api/video/detailbulk` (returns `VideoFullOut` list; `count` capped at 1000).
- Both skip hidden/`ongoing_tournament` videos and enforce id >= 1.