### PR TITLE
Fix profile signature, video fetch, and watchers

### DIFF
--- a/front_end/src/components/widgets/IdentifierManager.vue
+++ b/front_end/src/components/widgets/IdentifierManager.vue
@@ -41,14 +41,14 @@
 
 <script setup lang="ts">
 import { ElInput, ElLink, ElNotification, ElTable, ElTableColumn } from 'element-plus';
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import IconCopy from './IconCopy.vue';
 
 import { BaseIconAdd, BaseIconDelete } from '@/components/common/icon';
 import { httpErrorNotification, unknownErrorNotification } from '@/components/Notifications';
-import { fetchUserIdentifiers } from '@/services/userService';
+import { fetchUserIdentifiers, fetchUserVideos } from '@/services/userService';
 import { store } from '@/store';
 import useCurrentInstance from '@/utils/common/useCurrentInstance';
 import { removeItem } from '@/utils/system/tools';
@@ -77,8 +77,7 @@ async function refresh() {
     }
 }
 
-onMounted(refresh);
-watch(() => user.value.id, refresh, { immediate: true });
+watch(user, refresh, { immediate: true });
 
 const identifierdata = computed(() => {
     const data = user.value.identifiers ? user.value.identifiers.map((value) => ({ data: value })) : [];
@@ -101,12 +100,15 @@ function delIdentifier(identifier: string) {
     }).catch(httpErrorNotification);
 }
 
-function addIdentifier(identifier: string) {
-    proxy.$axios.post('identifier/add/', {
-        identifier: identifier,
-    }).then(function (response) {
+async function addIdentifier(identifier: string) {
+    try {
+        const response = await proxy.$axios.post('identifier/add/', {
+            identifier: identifier,
+        });
         if (response.data.type === 'success') {
-            user.value.identifiers?.push(new_identifiers.value);
+            const identifiers = user.value.identifiers ?? [];
+            user.value.identifiers = [...identifiers, identifier];
+            user.value.videos = await fetchUserVideos(user.value.id, true);
             ElNotification({
                 title: t('identifierManager.addIdentifierSuccess'),
                 message: t('identifierManager.processedNVideos', [response.data.value]),
@@ -128,7 +130,9 @@ function addIdentifier(identifier: string) {
             unknownErrorNotification(response.data);
         }
         new_identifiers.value = '';
-    }).catch(httpErrorNotification);
+    } catch (error) {
+        httpErrorNotification(error);
+    }
 }
 </script>
 

--- a/front_end/src/components/widgets/IdentifierManager.vue
+++ b/front_end/src/components/widgets/IdentifierManager.vue
@@ -48,11 +48,15 @@ import IconCopy from './IconCopy.vue';
 
 import { BaseIconAdd, BaseIconDelete } from '@/components/common/icon';
 import { httpErrorNotification, unknownErrorNotification } from '@/components/Notifications';
-import { fetchUserIdentifiers, fetchUserVideos } from '@/services/userService';
+import { fetchUserIdentifiers } from '@/services/userService';
 import { store } from '@/store';
 import useCurrentInstance from '@/utils/common/useCurrentInstance';
 import { removeItem } from '@/utils/system/tools';
 import { UserProfile } from '@/utils/userprofile';
+
+const emit = defineEmits<{
+    (event: 'identifiersChanged'): void;
+}>();
 
 const { proxy } = useCurrentInstance();
 const new_identifiers = ref('');
@@ -108,7 +112,7 @@ async function addIdentifier(identifier: string) {
         if (response.data.type === 'success') {
             const identifiers = user.value.identifiers ?? [];
             user.value.identifiers = [...identifiers, identifier];
-            user.value.videos = await fetchUserVideos(user.value.id);
+            emit('identifiersChanged');
             ElNotification({
                 title: t('identifierManager.addIdentifierSuccess'),
                 message: t('identifierManager.processedNVideos', [response.data.value]),

--- a/front_end/src/components/widgets/IdentifierManager.vue
+++ b/front_end/src/components/widgets/IdentifierManager.vue
@@ -108,7 +108,7 @@ async function addIdentifier(identifier: string) {
         if (response.data.type === 'success') {
             const identifiers = user.value.identifiers ?? [];
             user.value.identifiers = [...identifiers, identifier];
-            user.value.videos = await fetchUserVideos(user.value.id, true);
+            user.value.videos = await fetchUserVideos(user.value.id);
             ElNotification({
                 title: t('identifierManager.addIdentifierSuccess'),
                 message: t('identifierManager.processedNVideos', [response.data.value]),

--- a/front_end/src/services/userService.ts
+++ b/front_end/src/services/userService.ts
@@ -199,10 +199,10 @@ export async function fetchUserIdentifiers(userId: number): Promise<string[]> {
 }
 
 const userVideosPendingRequests = new Map<number, Promise<VideoAbstract[]>>();
-export function fetchUserVideos(userId: number): Promise<VideoAbstract[]> {
+export function fetchUserVideos(userId: number, force = false): Promise<VideoAbstract[]> {
     const pendingRequest = userVideosPendingRequests.get(userId);
 
-    if (pendingRequest) return pendingRequest;
+    if (pendingRequest && !force) return pendingRequest;
 
     const promise = $axios.get('/api/userprofile/videolist', {
         params: { user_id: userId },

--- a/front_end/src/services/userService.ts
+++ b/front_end/src/services/userService.ts
@@ -199,10 +199,10 @@ export async function fetchUserIdentifiers(userId: number): Promise<string[]> {
 }
 
 const userVideosPendingRequests = new Map<number, Promise<VideoAbstract[]>>();
-export function fetchUserVideos(userId: number, force = false): Promise<VideoAbstract[]> {
+export function fetchUserVideos(userId: number): Promise<VideoAbstract[]> {
     const pendingRequest = userVideosPendingRequests.get(userId);
 
-    if (pendingRequest && !force) return pendingRequest;
+    if (pendingRequest) return pendingRequest;
 
     const promise = $axios.get('/api/userprofile/videolist', {
         params: { user_id: userId },

--- a/front_end/src/utils/userprofile.test.ts
+++ b/front_end/src/utils/userprofile.test.ts
@@ -178,10 +178,10 @@ describe('UserProfile', () => {
         });
 
         it('left_signature_n == 0', () => {
-            const lastAvatarChange = new Date('2023-05-01T00:00:00Z');
+            const lastSigChange = new Date('2023-05-01T00:00:00Z');
             const profile = new UserProfile({
                 left_signature_n: 0,
-                last_change_avatar: lastAvatarChange.toISOString(),
+                last_change_signature: lastSigChange.toISOString(),
             });
             // 下一次应为 2023-06-01T00:00:00Z
             const expected = new Date(Date.UTC(2023, 5, 1, 0, 0, 0));
@@ -214,10 +214,10 @@ describe('UserProfile', () => {
 
     describe('newSignatureBudget', () => {
         it('Normal', () => {
-            const lastAvatarChange = new Date('2023-01-15T00:00:00Z');
+            const lastSigChange = new Date('2023-01-15T00:00:00Z');
             const profile = new UserProfile({
                 left_signature_n: 4,
-                last_change_avatar: lastAvatarChange.toISOString(),
+                last_change_signature: lastSigChange.toISOString(),
             });
             const newDate = new Date('2024-03-10T00:00:00Z');
             expect(profile.newSignatureBudget(newDate)).toBe(18);

--- a/front_end/src/utils/userprofile.ts
+++ b/front_end/src/utils/userprofile.ts
@@ -82,8 +82,8 @@ export class UserProfile {
 
     public get nextSignatureAvailable(): Date {
         if (this.left_signature_n > 0) return this.last_change_signature;
-        const year = this.last_change_avatar.getUTCFullYear();
-        const month = this.last_change_avatar.getUTCMonth();
+        const year = this.last_change_signature.getUTCFullYear();
+        const month = this.last_change_signature.getUTCMonth();
         const targetTimestamp = Date.UTC(year, month + 1, 1, 0, 0, 0, 0);
         return new Date(targetTimestamp);
     }
@@ -93,6 +93,6 @@ export class UserProfile {
     }
 
     public newSignatureBudget(newDate: Date): number {
-        return this.left_signature_n + 12 * (newDate.getUTCFullYear() - this.last_change_avatar.getUTCFullYear()) + (newDate.getUTCMonth() - this.last_change_avatar.getUTCMonth());
+        return this.left_signature_n + 12 * (newDate.getUTCFullYear() - this.last_change_signature.getUTCFullYear()) + (newDate.getUTCMonth() - this.last_change_signature.getUTCMonth());
     }
 }

--- a/front_end/src/views/UserView/App.vue
+++ b/front_end/src/views/UserView/App.vue
@@ -83,8 +83,7 @@ async function refresh() {
     playerLoading.value = false;
 }
 
-watch(() => route.params.id, refresh, { immediate: true });
-// onMounted(refresh);
+watch([() => route.params.id, () => store.user.id], refresh, { immediate: true });
 
 const i18nMessages = {
     'zh-cn': { local: {

--- a/front_end/src/views/UserView/UserSummaryView.vue
+++ b/front_end/src/views/UserView/UserSummaryView.vue
@@ -23,7 +23,7 @@
                     <IdentifierHelper style="width: 60%; min-width: 400px; max-width: 100%; margin: auto; display: block" />
                 </template>
             </BaseOverlay>
-            <IdentifierManager v-model:user="user" />
+            <IdentifierManager v-model:user="user" @identifiers-changed="refreshVideos" />
         </div>
     </div>
 </template>
@@ -58,11 +58,17 @@ async function refresh() {
     if (loading.value) return;
     if (user.value.id < 1) return;
     if (user.value.videos === undefined) {
-        loading.value = true;
-        user.value.videos = await fetchUserVideos(user.value.id);
-        loading.value = false;
+        await refreshVideos();
     }
 }
 
 watch(user, refresh, { immediate: true });
+
+async function refreshVideos() {
+    if (loading.value) return;
+    if (user.value.id < 1) return;
+    loading.value = true;
+    user.value.videos = await fetchUserVideos(user.value.id);
+    loading.value = false;
+}
 </script>

--- a/front_end/src/views/UserView/UserSummaryView.vue
+++ b/front_end/src/views/UserView/UserSummaryView.vue
@@ -30,7 +30,7 @@
 
 <script setup lang="ts">
 import { ElScrollbar } from 'element-plus';
-import { defineAsyncComponent, onMounted, ref, watch } from 'vue';
+import { defineAsyncComponent, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import '@/styles/text.css';
@@ -64,7 +64,5 @@ async function refresh() {
     }
 }
 
-watch(() => user.value.id, refresh, { immediate: true });
-
-onMounted(refresh);
+watch(user, refresh, { immediate: true });
 </script>

--- a/front_end/src/views/UserView/UserUploadView.vue
+++ b/front_end/src/views/UserView/UserUploadView.vue
@@ -1,10 +1,16 @@
 <template>
-    <VideoUpload :is-user-anonymous="user.isAnonymous" :identifiers="user.identifiers" @on-upload="(video) => { user.videos?.push(video); }" />
+    <VideoUpload :is-user-anonymous="user.isAnonymous" :identifiers="user.identifiers" @on-upload="handleUpload" />
 </template>
 
 <script setup lang="ts">
 import VideoUpload from '@/components/VideoUpload/App.vue';
 import { UserProfile } from '@/utils/userprofile';
+import type { VideoAbstract } from '@/utils/videoabstract';
 
 const user = defineModel('user', { type: UserProfile, required: true });
+
+function handleUpload(video: VideoAbstract) {
+    user.value.videos ??= [];
+    user.value.videos.push(video);
+}
 </script>

--- a/front_end/src/views/UserView/UserVideoView.vue
+++ b/front_end/src/views/UserView/UserVideoView.vue
@@ -7,13 +7,13 @@
         </ElButton>
     </ElRow>
     <MultiSelector v-if="showSetting" v-model="VideoListConfig.profile" :options="thisColumnChoices" :labels="thisColumnChoices.map((s) => t(`common.prop.${s}`))" />
-    <VideoList v-loading="loading" :videos="user.videos" :columns="VideoListConfig.profile" sortable paginator />
+    <VideoList v-if="user.id > 0 && user.videos !== undefined" v-loading="loading" :videos="user.videos" :columns="VideoListConfig.profile" sortable paginator />
 </template>
 
 <script lang="ts" setup>
 // 个人主页的个人所有录像部分
 import { ElButton, ElRow, vLoading } from 'element-plus';
-import { onMounted, ref, watch } from 'vue';
+import { ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { BaseIconSetting } from '@/components/common/icon';
@@ -45,7 +45,5 @@ async function refresh() {
     }
 }
 
-watch(() => user.value.id, refresh, { immediate: true });
-
-onMounted(refresh);
+watch(user, refresh, { immediate: true });
 </script>


### PR DESCRIPTION
- Refactor user-related views and services: switch several components to watch the whole user object (instead of `user.id`) and remove redundant `onMounted` calls.
- Make `addIdentifier` async, refresh `user.videos` after adding an identifier and handle HTTP errors.
- Refactor `IdentifierManager` to emit `identifiersChanged` event instead of directly fetching videos. The parent component (`UserSummaryView`) now handles video refresh logic through the new `refreshVideos()` function. This improves component separation of concerns and makes the component more reusable.
- Fix `UserProfile` to use `last_change_signature` for signature budget/availability (and update tests).
- Add safe checks and upload handler for pushing new videos to the user model to avoid undefined issues.