### PR TITLE
Add Bilibili account integration

### DIFF
--- a/back_end/saolei/accountlink/models.py
+++ b/back_end/saolei/accountlink/models.py
@@ -8,6 +8,7 @@ from videomanager.models import VideoModel
 
 
 class Platform(models.TextChoices):
+    BILIBILI = 'B', ('Bilibili')
     MSGAMES = 'a', ('Authoritative Minesweeper')
     QQ = 'q', ('腾讯QQ')
     SAOLEI = 'c', ('扫雷网')
@@ -20,25 +21,6 @@ class AccountLinkQueue(models.Model):
     identifier = models.CharField(max_length=128, null=False)
     userprofile = models.ForeignKey(UserProfile, on_delete=models.CASCADE)
     verified = models.BooleanField(default=False)
-
-# 网站编码 website code
-# a - Authoritative Minesweeper
-# c - China ranking (saolei.wang)
-# g - Minesweeper GO
-# l - League of Minesweeper
-# s - Scoreganizer
-# w - World of Minesweeper
-# B - Bilibili
-# D - Discord
-# F - Facebook
-# G - GitHub
-# R - Reddit
-# S - Speedrun.com
-# T - Tieba
-# W - Weibo
-# X - X
-# Y - YouTube
-# Z - Zhihu
 
 
 # 扫雷网账号信息
@@ -101,6 +83,23 @@ class AccountMinesweeperGames(models.Model):
     # mouse_model = models.CharField() # 用户自己随便填的，需要审查
 
 
+class AccountBilibili(models.Model):
+    id = models.PositiveBigIntegerField(primary_key=True, verbose_name='Bilibili UID', help_text='Numeric Bilibili user ID from space.bilibili.com/{uid}.')
+    parent = models.OneToOneField(UserProfile, on_delete=models.CASCADE, related_name='account_bilibili', verbose_name='OpenMS user', help_text='OpenMS user linked to this Bilibili account.')
+    update_time = models.DateTimeField(auto_now=True, verbose_name='Update time', help_text='Time when public Bilibili profile data was last synchronized.')
+
+    name = models.CharField(max_length=128, default='', verbose_name='Display name', help_text='Public Bilibili display name.')
+    face = models.URLField(max_length=500, default='', verbose_name='Avatar URL', help_text='Public Bilibili avatar URL.')
+    sign = models.TextField(default='', verbose_name='Signature', help_text='Public Bilibili profile signature.')
+    level = models.PositiveSmallIntegerField(default=0, help_text='Bilibili user level.')
+    following = models.PositiveIntegerField(default=0, verbose_name='Following count')
+    follower = models.PositiveIntegerField(default=0, verbose_name='Follower count')
+    video_count = models.PositiveIntegerField(default=0, help_text='Number of public video submissions by this Bilibili account.')
+    article_count = models.PositiveIntegerField(default=0, help_text='Number of public article submissions by this Bilibili account.')
+    opus_count = models.PositiveIntegerField(default=0, help_text='Number of public opus/dynamic posts by this Bilibili account.')
+    official_title = models.CharField(max_length=128, default='', verbose_name='Official title', help_text='Bilibili official verification title, or an empty string when unverified.')
+
+
 class AccountWorldOfMinesweeper(models.Model):
     id = models.PositiveIntegerField(primary_key=True)
     parent = models.OneToOneField(UserProfile, on_delete=models.CASCADE, related_name='account_wom')
@@ -154,6 +153,10 @@ class AccountQQ(models.Model):
 
 
 PLATFORM_CONFIG = {
+    Platform.BILIBILI: {
+        'model': AccountBilibili,
+        'related_name': 'account_bilibili',
+    },
     Platform.MSGAMES: {
         'model': AccountMinesweeperGames,
         'related_name': 'account_msgames',

--- a/back_end/saolei/accountlink/services.py
+++ b/back_end/saolei/accountlink/services.py
@@ -14,7 +14,7 @@ from utils.parser import MSVideoParser
 from utils.saolei import SaoleiUserInfo, SaoleiUtils
 from videomanager.models import VideoModel
 from .models import AccountSaolei, Platform, VideoSaolei
-from .utils import fetch_saolei_profile, fetch_saolei_video_download_and_state, update_msgames_account, update_wom_account
+from .utils import fetch_saolei_profile, fetch_saolei_video_download_and_state, update_bilibili_account, update_msgames_account, update_wom_account
 
 logger = logging.getLogger('accountlink')
 
@@ -26,6 +26,8 @@ def update_account(platform: Platform, user: UserProfile):
         update_msgames_account(user.account_msgames)
     elif platform == Platform.WOM:
         update_wom_account(user.account_wom)
+    elif platform == Platform.BILIBILI:
+        update_bilibili_account(user.account_bilibili)
 
 
 def update_saolei_account_info(account: AccountSaolei):

--- a/back_end/saolei/accountlink/tests.py
+++ b/back_end/saolei/accountlink/tests.py
@@ -5,9 +5,9 @@ from django.test import TestCase
 import requests
 
 from userprofile.models import UserProfile
-from .models import AccountMinesweeperGames, AccountSaolei, AccountWorldOfMinesweeper
+from .models import AccountBilibili, AccountMinesweeperGames, AccountSaolei, AccountWorldOfMinesweeper, Platform
 from .services import update_saolei_account_info
-from .utils import update_msgames_account, update_wom_account
+from .utils import isPrivate, private_platforms, update_bilibili_account, update_msgames_account, update_wom_account
 
 
 class AccountLinkTestCase(TestCase):
@@ -17,6 +17,7 @@ class AccountLinkTestCase(TestCase):
         AccountSaolei.objects.create(id=1, parent=user)
         AccountMinesweeperGames.objects.create(id=7872, parent=user)
         AccountWorldOfMinesweeper.objects.create(id=1783173, parent=user)
+        AccountBilibili.objects.create(id=208259, parent=user)
 
     def test_update_saolei(self):
         account = AccountSaolei.objects.filter(id=1).first()
@@ -44,6 +45,35 @@ class AccountLinkTestCase(TestCase):
         self.assertEqual(account.name, 'Ze-En JU')
         self.assertEqual(account.local_name, '鞠泽恩')
         self.assertEqual(account.joined, datetime.date(2019, 5, 28))
+
+    def test_update_bilibili(self):
+        account = AccountBilibili.objects.filter(id=208259).first()
+        update_bilibili_account(account)
+        account = AccountBilibili.objects.filter(id=208259).first()
+
+        self.assertEqual(account.id, 208259)
+        self.assertEqual(account.name, '陈睿')
+        self.assertEqual(account.level, 6)
+        self.assertIn('bilibili', account.official_title)
+        self.assertTrue(account.face.startswith(('http://', 'https://')))
+        self.assertTrue(account.sign)
+
+        self.assertGreater(account.following, 100)
+        self.assertLess(account.following, 5000)
+        self.assertGreater(account.follower, 1000000)
+        self.assertLess(account.follower, 5000000)
+        self.assertGreaterEqual(account.video_count, 10)
+        self.assertLess(account.video_count, 100)
+        self.assertGreaterEqual(account.article_count, 0)
+        self.assertLess(account.article_count, 100)
+        self.assertGreaterEqual(account.opus_count, 100)
+        self.assertLess(account.opus_count, 1000)
+
+    def test_private_platforms(self):
+        self.assertIn(Platform.QQ, private_platforms)
+        self.assertTrue(isPrivate(Platform.QQ))
+        self.assertFalse(isPrivate(Platform.BILIBILI))
+        self.assertFalse(isPrivate(Platform.SAOLEI))
 
     @expectedFailure
     def test_update_wom(self):

--- a/back_end/saolei/accountlink/utils.py
+++ b/back_end/saolei/accountlink/utils.py
@@ -1,8 +1,8 @@
 import re
 
-from lxml import etree
 from bilibili_api import sync
 from bilibili_api.user import User
+from lxml import etree
 import requests
 
 from config.text_choices import Saolei_TextChoices

--- a/back_end/saolei/accountlink/utils.py
+++ b/back_end/saolei/accountlink/utils.py
@@ -2,15 +2,22 @@ import re
 
 from lxml import etree
 import requests
+from bilibili_api import sync
+from bilibili_api.user import User
 
 from config.text_choices import Saolei_TextChoices
 from userprofile.models import UserProfile
 from utils.exceptions import ExceptionToResponse
-from .models import AccountMinesweeperGames, AccountWorldOfMinesweeper, Platform, PLATFORM_CONFIG
+from .models import AccountBilibili, AccountMinesweeperGames, AccountWorldOfMinesweeper, Platform, PLATFORM_CONFIG
 
 headers = {
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36 Edg/132.0.0.0',
 }
+private_platforms = [Platform.QQ]
+
+
+def isPrivate(platform) -> bool:
+    return platform in private_platforms
 
 
 def link_account(platform: Platform, linkid, user: UserProfile):
@@ -30,6 +37,8 @@ def delete_account(user: UserProfile, platform: Platform):
         user.account_msgames.delete()
     elif platform == Platform.WOM:
         user.account_wom.delete()
+    elif platform == Platform.BILIBILI:
+        user.account_bilibili.delete()
 
 
 def fetch_saolei_profile(saolei_id: int):
@@ -153,6 +162,31 @@ def update_msgames_account(account: AccountMinesweeperGames):
     account.name = str(getValue('Name'))
     account.local_name = str(getValue('Local Name'))
     account.joined = getValue('Joined')
+    account.save()
+
+
+def update_bilibili_account(account: AccountBilibili):
+    bili_user = User(uid=account.id)
+    try:
+        info = sync(bili_user.get_user_info())
+        relation = sync(bili_user.get_relation_info())
+        overview = sync(bili_user.get_overview_stat())
+    except TimeoutError:
+        raise ExceptionToResponse(obj='import', category='timeout')
+    except Exception:
+        raise ExceptionToResponse(obj='import', category='requestexception')
+
+    official = info.get('official', {})
+    account.name = info.get('name', '') or ''
+    account.face = info.get('face', '') or ''
+    account.sign = info.get('sign', '') or ''
+    account.level = info.get('level', 0) or 0
+    account.following = relation.get('following', 0) or 0
+    account.follower = relation.get('follower', 0) or 0
+    account.video_count = overview.get('video', 0) or 0
+    account.article_count = overview.get('article', 0) or 0
+    account.opus_count = overview.get('opus', 0) or 0
+    account.official_title = official.get('title', '') or ''
     account.save()
 
 

--- a/back_end/saolei/accountlink/utils.py
+++ b/back_end/saolei/accountlink/utils.py
@@ -1,9 +1,9 @@
 import re
 
 from lxml import etree
-import requests
 from bilibili_api import sync
 from bilibili_api.user import User
+import requests
 
 from config.text_choices import Saolei_TextChoices
 from userprofile.models import UserProfile

--- a/back_end/saolei/accountlink/views.py
+++ b/back_end/saolei/accountlink/views.py
@@ -13,10 +13,9 @@ from utils.response import HttpResponseConflict
 from .models import AccountLinkQueue, AccountSaolei, Platform, PLATFORM_CONFIG, VideoSaolei
 from .services import saolei_video_import_one, update_account
 from .tasks import helper_saolei_video_import_bulk
-from .utils import delete_account, link_account
+from .utils import delete_account, isPrivate, link_account, private_platforms
 
 logger = logging.getLogger('accountlink')
-private_platforms = ['q']  # 私人账号平台
 
 
 # 为自己绑定账号，需要指定平台和ID
@@ -58,7 +57,7 @@ def get_link(request):
     if not (user := UserProfile.objects.filter(id=userid).first()):
         return HttpResponseNotFound()
     if platform := request.GET.get('platform'):
-        if platform in private_platforms and not request.user.is_staff and user != request.user:
+        if isPrivate(platform) and not request.user.is_staff and user != request.user:
             return HttpResponseForbidden()
         account = getattr(user, PLATFORM_CONFIG[platform]['related_name'])
         data = model_to_dict(account)

--- a/back_end/saolei/requirements.txt
+++ b/back_end/saolei/requirements.txt
@@ -1,4 +1,6 @@
 beautifulsoup4==4.15.0
+bilibili-api-python==17.4.2
+curl_cffi==0.15.0
 Django==6.0.6
 django-apscheduler==0.7.0
 django-cleanup==9.0.0


### PR DESCRIPTION
- Introduce Bilibili support: add `Platform.BILIBILI, AccountBilibili` model and `PLATFORM_CONFIG` entry; implement `update_bilibili_account` using `bilibili_api` and wire it into account update/delete flows.
- Add `isPrivate`/`private_platforms` helper and replace local privacy check in views.
- Update tests to cover Bilibili syncing and private-platform behavior.
- Add `bilibili-api-python` and `curl_cffi` to requirements.