### PR TITLE
Move AccountLinkGuide to accountlinks and use enums

### DIFF
--- a/front_end/src/components/accountlinks/CardAdd.cy.ts
+++ b/front_end/src/components/accountlinks/CardAdd.cy.ts
@@ -48,4 +48,33 @@ describe('<CardAdd />', () => {
         cy.get('.el-button').first().click();
         cy.get('.el-input input').should('have.value', '');
     });
+
+    it('renders the account link guide for each platform', () => {
+        mountAccountLink(CardAdd);
+
+        cy.get('.el-button').first().click();
+        cy.get('.el-select').click();
+        cy.contains('.el-select-dropdown__item', '扫雷网').click();
+        cy.contains('How to locate the ID');
+        cy.contains('Go to your profile page on');
+
+        cy.get('.el-select').click();
+        cy.contains('.el-select-dropdown__item', 'Authoritative Minesweeper').click();
+        cy.contains('Find yourself on the');
+        cy.contains('The number at the end of the url is your ID');
+
+        cy.get('.el-select').click();
+        cy.contains('.el-select-dropdown__item', 'Minesweeper.Online').click();
+        cy.contains('Go to your profile page on');
+
+        cy.get('.el-select').click();
+        cy.contains('.el-select-dropdown__item', '腾讯QQ').click();
+        cy.contains('The QQ number is accessible from site moderators');
+
+        cy.get('.el-select').click();
+        cy.contains('.el-select-dropdown__item', 'Bilibili').click();
+        cy.contains('space.bilibili.com');
+        cy.contains('Privacy notice');
+        cy.contains('Linking Bilibili may allow others');
+    });
 });

--- a/front_end/src/components/accountlinks/CardAdd.vue
+++ b/front_end/src/components/accountlinks/CardAdd.vue
@@ -16,7 +16,7 @@
             <ElFormItem label="ID">
                 <ElInput v-model="form.identifier" maxlength="128" />
             </ElFormItem>
-            <ElFormItem v-if="local.tooltip_show">
+            <ElFormItem v-if="local.tooltip_show && form.platform">
                 <AccountLinkGuide :platform="form.platform" />
             </ElFormItem>
         </ElForm>
@@ -32,10 +32,11 @@ import { ElButton, ElDialog, ElForm, ElFormItem, ElInput, ElOption, ElSelect } f
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+import AccountLinkGuide from './Guide.vue';
+
 import BaseButtonCancel from '@/components/common/BaseButtonCancel.vue';
 import BaseButtonConfirm from '@/components/common/BaseButtonConfirm.vue';
 import { BaseIconAdd } from '@/components/common/icon';
-import AccountLinkGuide from '@/components/dialogs/AccountLinkGuide.vue';
 import { local } from '@/store';
 import { AccountLinks, platformlist } from '@/utils/accountlinks';
 import type { AccountLinkPlatform } from '@/utils/accountlinks';

--- a/front_end/src/components/accountlinks/Guide.vue
+++ b/front_end/src/components/accountlinks/Guide.vue
@@ -1,11 +1,11 @@
 <template>
-    <span v-if="platform == 'c'" class="text">
+    <span v-if="platform == AccountLinkPlatform.Saolei" class="text">
         <b>{{ t('local.title') }}</b><br>
         {{ t('local.saolei1') }}
         <PlatformIcon platform="c" />{{ t('local.saolei2') }}<br>
         <img src="../../assets/IdGuideSaolei.png" width="100%">
     </span>
-    <span v-else-if="platform == 'a'" class="text">
+    <span v-else-if="platform == AccountLinkPlatform.MSGames" class="text">
         <b>{{ t('local.title') }}</b><br>
         {{ t('local.msgames1') }}
         <PlatformIcon platform="a" />{{ t('local.msgames2') }}<br>
@@ -13,16 +13,16 @@
         {{ t('local.msgames3') }}
         <img src="../../assets/IdGuideMsgames2.png" width="100%">
     </span>
-    <span v-else-if="platform == 'w'" class="text">
+    <span v-else-if="platform == AccountLinkPlatform.WoM" class="text">
         <b>{{ t('local.title') }}</b><br>
         {{ t('local.wom1') }}
         <PlatformIcon platform="w" />{{ t('local.wom2') }}
         <img src="../../assets/IdGuideWom.png" width="100%">
     </span>
-    <span v-else-if="platform == 'q'" class="text">
+    <span v-else-if="platform == AccountLinkPlatform.QQ" class="text">
         {{ t('local.QQ') }}
     </span>
-    <span v-else-if="platform == 'B'" class="text">
+    <span v-else-if="platform == AccountLinkPlatform.Bilibili" class="text">
         <b>{{ t('local.title') }}</b><br>
         {{ t('local.bilibili1') }}
         <PlatformIcon platform="B" />{{ t('local.bilibili2') }}<br>
@@ -34,14 +34,17 @@
 
 <script setup lang="ts">
 import '@/styles/text.css';
+import type { PropType } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import PlatformIcon from '@/components/widgets/PlatformIcon.vue';
+import { AccountLinkPlatform } from '@/utils/accountlinks';
+import type { AccountLinkPlatform as AccountLinkPlatformType } from '@/utils/accountlinks';
 
 defineProps({
     platform: {
-        type: String,
-        default: '',
+        type: String as PropType<AccountLinkPlatformType>,
+        required: true,
     },
 });
 


### PR DESCRIPTION
- Relocate `AccountLinkGuide` component from dialogs to accountlinks folder and rename to `Guide.vue`.
- Refactor platform comparisons to use `AccountLinkPlatform` enum constants instead of magic strings.
- Change platform prop to required and improve type safety.
- Add comprehensive test coverage for guide across all supported platforms.