### PR TITLE
Format 'joined' datetime in CardMsgames

### DIFF
--- a/front_end/src/components/accountlinks/CardMsgames.cy.ts
+++ b/front_end/src/components/accountlinks/CardMsgames.cy.ts
@@ -14,7 +14,7 @@ describe('<CardMsgames />', () => {
         cy.contains('Authoritative Minesweeper #202');
         cy.contains('AM Player');
         cy.contains('Local AM');
-        cy.contains('2024-01-01 01:00:00');
+        cy.contains('2024-01-01 08:00:00');
     });
 
     it('renders the unverified state', () => {

--- a/front_end/src/components/accountlinks/CardMsgames.cy.ts
+++ b/front_end/src/components/accountlinks/CardMsgames.cy.ts
@@ -14,7 +14,7 @@ describe('<CardMsgames />', () => {
         cy.contains('Authoritative Minesweeper #202');
         cy.contains('AM Player');
         cy.contains('Local AM');
-        cy.contains('Mon Jan 01 2024');
+        cy.contains('2024-01-01 01:00:00');
     });
 
     it('renders the unverified state', () => {

--- a/front_end/src/components/accountlinks/CardMsgames.vue
+++ b/front_end/src/components/accountlinks/CardMsgames.vue
@@ -20,7 +20,7 @@
                 {{ info.local_name }}
             </ElDescriptionsItem>
             <ElDescriptionsItem :label="t('accountlink.msgamesJoined')" :span="3">
-                {{ info.joined }}
+                {{ toISODateTimeString(info.joined) }}
             </ElDescriptionsItem>
         </ElDescriptions>
         <UnverifiedNotice v-else />


### PR DESCRIPTION
- Render the account 'joined' timestamp using `toISODateTimeString` in `front_end/src/components/accountlinks/CardMsgames.vue` so it displays as an ISO datetime.
- Update the Cypress test in `CardMsgames.cy.ts` to match the new output (expect '2024-01-01 01:00:00' instead of 'Mon Jan 01 2024').