### PR TITLE
Internationalize platform names in accountlinks

### DIFF
--- a/front_end/cypress/e2e/accountlink.cy.ts
+++ b/front_end/cypress/e2e/accountlink.cy.ts
@@ -13,7 +13,7 @@ const USER = {
 } as const;
 const LINKS = {
     bilibili: {
-        platform: 'Bilibili',
+        platform: '哔哩哔哩',
         identifier: '208259',
     },
     wom: {
@@ -25,7 +25,7 @@ const LINKS = {
         identifier: '18290',
     },
     msgames: {
-        platform: 'Authoritative Minesweeper',
+        platform: '国际网',
         identifier: '7872',
     },
     qq: {
@@ -199,7 +199,7 @@ describe('Account Link', () => {
             expect(cardTexts[0]).to.contain(`${LINKS.saolei.platform}\u00a0#${LINKS.saolei.identifier}`);
             expect(cardTexts[1]).to.contain(`${LINKS.msgames.platform}\u00a0#${LINKS.msgames.identifier}`);
             expect(cardTexts[2]).to.contain(`${LINKS.wom.platform}\u00a0#${LINKS.wom.identifier}`);
-            expect(cardTexts[3]).to.contain(`Bilibili\u00a0#${LINKS.bilibili.identifier}`);
+            expect(cardTexts[3]).to.contain(`${LINKS.bilibili.platform}\u00a0#${LINKS.bilibili.identifier}`);
         });
     });
 });

--- a/front_end/src/components/accountlinks/CardAdd.cy.ts
+++ b/front_end/src/components/accountlinks/CardAdd.cy.ts
@@ -24,7 +24,7 @@ describe('<CardAdd />', () => {
 
         cy.get('.el-button').first().click();
         cy.get('.el-select').click();
-        cy.contains('.el-select-dropdown__item', '扫雷网').should('have.class', 'is-disabled');
+        cy.contains('.el-select-dropdown__item', 'Saolei.wang').should('have.class', 'is-disabled');
         cy.contains('.el-select-dropdown__item', 'Bilibili').click();
 
         cy.contains('button', 'Confirm').should('be.disabled');
@@ -54,7 +54,7 @@ describe('<CardAdd />', () => {
 
         cy.get('.el-button').first().click();
         cy.get('.el-select').click();
-        cy.contains('.el-select-dropdown__item', '扫雷网').click();
+        cy.contains('.el-select-dropdown__item', 'Saolei.wang').click();
         cy.contains('How to locate the ID');
         cy.contains('Go to your profile page on');
 
@@ -68,7 +68,7 @@ describe('<CardAdd />', () => {
         cy.contains('Go to your profile page on');
 
         cy.get('.el-select').click();
-        cy.contains('.el-select-dropdown__item', '腾讯QQ').click();
+        cy.contains('.el-select-dropdown__item', 'Tencent QQ').click();
         cy.contains('The QQ number is accessible from site moderators');
 
         cy.get('.el-select').click();

--- a/front_end/src/components/accountlinks/CardAdd.vue
+++ b/front_end/src/components/accountlinks/CardAdd.vue
@@ -8,7 +8,7 @@
             <ElFormItem :label="t('accountlink.platform')">
                 <ElSelect v-model="form.platform">
                     <ElOption
-                        v-for="(item, key) of platformlist" :key="key" :value="key" :label="item.name"
+                        v-for="(_, key) of platformlist" :key="key" :value="key" :label="t(`common.platform.${key}`)"
                         :disabled="userHasPlatform(key)"
                     />
                 </ElSelect>

--- a/front_end/src/components/accountlinks/CardBilibili.vue
+++ b/front_end/src/components/accountlinks/CardBilibili.vue
@@ -4,7 +4,7 @@
             <PrToolbar>
                 <template #start>
                     <span class="text text-medium">
-                        Bilibili&nbsp;#{{ id }}
+                        {{ t('common.platform.B') }}&nbsp;#{{ id }}
                     </span>
                 </template>
                 <template #end>

--- a/front_end/src/components/accountlinks/CardMsgames.vue
+++ b/front_end/src/components/accountlinks/CardMsgames.vue
@@ -4,7 +4,7 @@
             <PrToolbar>
                 <template #start>
                     <span class="text text-medium">
-                        Authoritative Minesweeper&nbsp;#{{ id }}
+                        {{ t('common.platform.a') }}&nbsp;#{{ id }}
                     </span>
                 </template>
             </PrToolbar>

--- a/front_end/src/components/accountlinks/CardSaolei.vue
+++ b/front_end/src/components/accountlinks/CardSaolei.vue
@@ -4,7 +4,7 @@
             <PrToolbar>
                 <template #start>
                     <span class="text text-medium">
-                        {{ t('common.website.saolei') }}&nbsp;#{{ id }}
+                        {{ t('common.platform.c') }}&nbsp;#{{ id }}
                     </span>
                 </template>
                 <template #end>

--- a/front_end/src/components/accountlinks/CardWoM.vue
+++ b/front_end/src/components/accountlinks/CardWoM.vue
@@ -4,7 +4,7 @@
             <PrToolbar>
                 <template #start>
                     <span class="text text-medium">
-                        Minesweeper.Online&nbsp;#{{ id }}
+                        {{ t('common.platform.w') }}&nbsp;#{{ id }}
                     </span>
                 </template>
                 <template #end>

--- a/front_end/src/components/widgets/PlatformIcon.vue
+++ b/front_end/src/components/widgets/PlatformIcon.vue
@@ -1,20 +1,23 @@
 <template>
-    <!-- @vue-expect-error -->
     <ElLink :href="platformlist[platform].url" target="_blank" rel="noopener noreferrer" style="vertical-align: bottom;">
-        <!-- @vue-expect-error -->
-        {{ platformlist[platform].name }}
+        {{ t(`common.platform.${platform}`) }}
     </ElLink>
 </template>
 
 <script setup lang="ts">
 import { ElLink } from 'element-plus';
+import type { PropType } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import { platformlist } from '@/utils/accountlinks';
+import type { AccountLinkPlatform } from '@/utils/accountlinks';
 
 defineProps({
     platform: {
-        type: String,
-        default: '',
+        type: String as PropType<AccountLinkPlatform>,
+        required: true,
     },
 });
+
+const { t } = useI18n();
 </script>

--- a/front_end/src/i18n/locales/dev.ts
+++ b/front_end/src/i18n/locales/dev.ts
@@ -1,6 +1,9 @@
 export default {
     local: 'dev',
     common: {
+        platform: {
+            w: 'Minesweeper.Online',
+        },
         prop: {
             bv: 'Bv',
             bbbv: 'Bv',

--- a/front_end/src/i18n/locales/en.ts
+++ b/front_end/src/i18n/locales/en.ts
@@ -65,6 +65,12 @@ export default {
         },
         new: 'New',
         old: 'Old',
+        platform: {
+            a: 'Authoritative Minesweeper',
+            B: 'Bilibili',
+            c: 'Saolei.wang',
+            q: 'Tencent QQ',
+        },
         prop: {
             action: 'Action',
             identifier: 'Identifier',
@@ -128,6 +134,7 @@ export default {
         },
         toDo: 'TODO',
         website: {
+            bilibili: 'Bilibili',
             msgames: 'Authoritative Minesweeper',
             openms: 'Open Minesweeper',
             saolei: 'Saolei.wang',

--- a/front_end/src/i18n/locales/zh-cn.ts
+++ b/front_end/src/i18n/locales/zh-cn.ts
@@ -64,6 +64,12 @@ export default {
         },
         new: '新',
         old: '旧',
+        platform: {
+            a: '国际网',
+            B: '哔哩哔哩',
+            c: '扫雷网',
+            q: '腾讯QQ',
+        },
         prop: {
             action: '操作',
             identifier: '标识',
@@ -127,6 +133,7 @@ export default {
         },
         toDo: '敬请期待',
         website: {
+            bilibili: '哔哩哔哩',
             msgames: '国际网',
             openms: '开源扫雷网',
             saolei: '扫雷网',

--- a/front_end/src/utils/accountlinks/platforms.ts
+++ b/front_end/src/utils/accountlinks/platforms.ts
@@ -14,15 +14,14 @@ export const AccountLinkPlatform = {
 export type AccountLinkPlatform = typeof AccountLinkPlatform[keyof typeof AccountLinkPlatform];
 
 interface AccountLinkPlatformProfile {
-    name: string;
     url: string;
     profile: (id: string | number) => string;
 }
 
 export const platformlist: Record<AccountLinkPlatform, AccountLinkPlatformProfile> = {
-    [AccountLinkPlatform.Bilibili]: { name: 'Bilibili', url: 'https://www.bilibili.com/', profile: bilibiliProfile },
-    [AccountLinkPlatform.MSGames]: { name: 'Authoritative Minesweeper', url: 'https://minesweepergame.com/', profile: msgamesProfile },
-    [AccountLinkPlatform.Saolei]: { name: '扫雷网', url: 'http://saolei.wang/', profile: saoleiProfile },
-    [AccountLinkPlatform.QQ]: { name: '腾讯QQ', url: 'https://im.qq.com/index/', profile: qqProfile },
-    [AccountLinkPlatform.WoM]: { name: 'Minesweeper.Online', url: 'https://minesweeper.online/', profile: womProfile },
+    [AccountLinkPlatform.Bilibili]: { url: 'https://www.bilibili.com/', profile: bilibiliProfile },
+    [AccountLinkPlatform.MSGames]: { url: 'https://minesweepergame.com/', profile: msgamesProfile },
+    [AccountLinkPlatform.Saolei]: { url: 'http://saolei.wang/', profile: saoleiProfile },
+    [AccountLinkPlatform.QQ]: { url: 'https://im.qq.com/index/', profile: qqProfile },
+    [AccountLinkPlatform.WoM]: { url: 'https://minesweeper.online/', profile: womProfile },
 };

--- a/front_end/src/views/StaffView/AccountLink.vue
+++ b/front_end/src/views/StaffView/AccountLink.vue
@@ -5,7 +5,7 @@
         </ElFormItem>
         <ElFormItem label="平台">
             <ElSelect v-model="form.platform">
-                <ElOption v-for="(item, key) of platformlist" :key="key" :label="item.name" :value="key" />
+                <ElOption v-for="(_, key) of platformlist" :key="key" :label="t(`common.platform.${key}`)" :value="key" />
             </ElSelect>
         </ElFormItem>
         <ElFormItem label="平台ID">
@@ -33,7 +33,7 @@
         <PrColumn field="userprofile" header="User ID" sortable />
         <PrColumn field="platform" header="Platform" sortable>
             <template #body="{ data }: { data: AccountLinkQueueItem }">
-                {{ platformlist[data.platform]?.name ?? data.platform }}
+                {{ t(`common.platform.${data.platform}`) }}
             </template>
         </PrColumn>
         <PrColumn field="identifier" header="Platform ID" sortable />
@@ -46,6 +46,7 @@ import { ElButton, ElForm, ElFormItem, ElInput, ElOption, ElSelect, vLoading } f
 import PrColumn from 'primevue/column';
 import PrDataTable from 'primevue/datatable';
 import { onMounted, reactive, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import { httpErrorNotification } from '@/components/Notifications';
 import type { AccountLinkPlatform } from '@/utils/accountlinks';
@@ -53,6 +54,7 @@ import { platformlist } from '@/utils/accountlinks';
 import useCurrentInstance from '@/utils/common/useCurrentInstance';
 
 const { proxy } = useCurrentInstance();
+const { t } = useI18n();
 
 interface AccountLinkQueueItem {
     id: number | null;


### PR DESCRIPTION
- Move hardcoded platform names to i18n translations to support multiple languages.
- Remove the `name` field from platform definitions and update all components to use `t('common.platform.${key}')` for platform display.
- Add translations for platform names in en and zh-cn locales.
- This also improves type safety in PlatformIcon component.