### PR TITLE
Use sum getters for saolei account stats

### DIFF
--- a/front_end/src/components/accountlinks/CardSaolei.vue
+++ b/front_end/src/components/accountlinks/CardSaolei.vue
@@ -40,9 +40,9 @@
                         {{ cs_to_s(info.e_b_cent!) }}
                     </ElDescriptionsItem>
                     <ElDescriptionsItem :label="t('common.level.sum')">
-                        {{ cs_to_s((info.b_t_ms! + info.i_t_ms! + info.e_t_ms!) / 10) }}
+                        {{ cs_to_s(info.sum_t_ms / 10) }}
                         &nbsp;|&nbsp;
-                        {{ cs_to_s(info.b_b_cent! + info.i_b_cent! + info.e_b_cent!) }}
+                        {{ cs_to_s(info.sum_b_cent) }}
                     </ElDescriptionsItem>
                 </ElDescriptions>
             </ElCarouselItem>

--- a/front_end/src/utils/accountlinks/saolei.ts
+++ b/front_end/src/utils/accountlinks/saolei.ts
@@ -53,6 +53,14 @@ export class AccountSaolei {
         this.i_b_cent = data.i_b_cent ?? this.i_b_cent;
         this.e_b_cent = data.e_b_cent ?? this.e_b_cent;
     }
+
+    public get sum_t_ms(): number {
+        return this.b_t_ms + this.i_t_ms + this.e_t_ms;
+    }
+
+    public get sum_b_cent(): number {
+        return this.b_b_cent + this.i_b_cent + this.e_b_cent;
+    }
 }
 
 export interface SaoleiVideoRaw {


### PR DESCRIPTION
- Add `sum_t_ms` and `sum_b_cent` getters to `AccountSaolei` to centralize aggregation of time (`t_ms`) and cent (`b_cent`) values.
- Update `CardSaolei.vue` to use these getters (displaying `sum_t_ms / 10` and `sum_b_cent`) instead of inline arithmetic.
- Small refactor for readability and to avoid repeated calculations.