### PR TITLE
Add native video player with custom counters

### DIFF
--- a/front_end/src/components/VideoPlayer/App.vue
+++ b/front_end/src/components/VideoPlayer/App.vue
@@ -12,12 +12,14 @@
                     {{ t('local.player') }}
                     <ElSelect v-model="videoPlayerConfig.backend" style="width: 10rem">
                         <ElOption key="flop" value="flop" label="flop-player" />
+                        <ElOption key="native" value="native" label="native" />
                         <ElOption key="StrangeDust" value="StrangeDust" label="strange-dust.github.io" />
                     </ElSelect>
                 </span>
             </div>
         </template>
         <FlopPlayer v-if="videoPlayerConfig.backend == 'flop'" :src="videoplayerstore.url" />
+        <NativePlayer v-if="videoPlayerConfig.backend == 'native'" :src="videoplayerstore.url" />
         <StrangeDust v-if="videoPlayerConfig.backend == 'StrangeDust'" :src="videoplayerstore.url" />
     </ElDialog>
 </template>
@@ -27,6 +29,7 @@ import { ElDialog, ElOption, ElSelect } from 'element-plus';
 import { useI18n } from 'vue-i18n';
 
 import FlopPlayer from './FlopPlayer.vue';
+import NativePlayer from './NativePlayer.vue';
 import StrangeDust from './StrangeDust.vue';
 
 import { videoPlayerConfig, videoplayerstore } from '@/store';

--- a/front_end/src/components/VideoPlayer/CustomCounter.vue
+++ b/front_end/src/components/VideoPlayer/CustomCounter.vue
@@ -1,0 +1,126 @@
+<template>
+    <div class="custom-counter-wrap">
+        <table class="custom-counter">
+            <tbody>
+                <tr v-for="(row, index) in rows" :key="index">
+                    <th>{{ row.label }}</th>
+                    <td :class="{ 'custom-counter__value--error': row.error }">
+                        {{ row.value }}
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { Parser } from 'expr-eval';
+import type { PropType } from 'vue';
+import { computed } from 'vue';
+
+import { videoNumericParamKeys } from './types';
+import type { CustomCounterConfig } from './types';
+
+import type { AnyVideo } from '@/utils/fileIO';
+
+const props = defineProps({
+    video: { type: Object as PropType<AnyVideo>, required: true },
+    currentMs: { type: Number, required: true },
+    config: { type: Array as PropType<CustomCounterConfig>, required: true },
+});
+
+type DynamicParamValues = Record<string, unknown>;
+
+const allowedKeys = new Set<string>(videoNumericParamKeys);
+const parser = new Parser({
+    operators: {
+        assignment: false,
+    },
+});
+
+const rows = computed(() => {
+    void props.currentMs;
+    const values = createEvaluationContext(props.video);
+    return props.config.map(([label, expression]) => {
+        const result = evaluateExpression(expression, values);
+        return {
+            label,
+            ...result,
+        };
+    });
+});
+
+function evaluateExpression(expression: string, values: DynamicParamValues) {
+    try {
+        const parsed = parser.parse(expression);
+        const unknownVariables = parsed.variables().filter((key) => !allowedKeys.has(key));
+        if (unknownVariables.length > 0) throw new Error(`Unknown variable: ${unknownVariables.join(', ')}`);
+        return { error: false, value: String(parsed.evaluate(values as Parameters<typeof parsed.evaluate>[0])) };
+    } catch (error) {
+        return { error: true, value: formatError(error) };
+    }
+}
+
+function formatError(error: unknown) {
+    if (error instanceof Error && error.message !== '') return error.message;
+    return String(error);
+}
+
+function createEvaluationContext(video: AnyVideo) {
+    const values: DynamicParamValues = {};
+    for (const key of videoNumericParamKeys) {
+        Object.defineProperty(values, key, {
+            enumerable: true,
+            get: () => video[key],
+        });
+    }
+    return values;
+}
+</script>
+
+<style scoped>
+.custom-counter-wrap {
+    max-height: calc(100vh - 290px);
+    overflow-y: auto;
+}
+
+.custom-counter {
+    table-layout: fixed;
+    border-collapse: collapse;
+    color: var(--el-text-color-regular);
+    font-size: 12px;
+    line-height: 1.25;
+}
+
+.custom-counter th,
+.custom-counter td {
+    border: 1px solid var(--el-border-color);
+    padding: 3px 6px;
+}
+
+.custom-counter th {
+    width: 90px;
+    color: var(--el-text-color-secondary);
+    font-weight: 500;
+    text-align: left;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.custom-counter td {
+    width: 130px;
+    overflow: hidden;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+    text-overflow: clip;
+    white-space: pre;
+}
+
+.custom-counter__value--error {
+    color: var(--el-color-danger);
+    overflow-wrap: anywhere;
+    text-align: left;
+    white-space: normal;
+}
+</style>

--- a/front_end/src/components/VideoPlayer/CustomCounterConfigEditor.vue
+++ b/front_end/src/components/VideoPlayer/CustomCounterConfigEditor.vue
@@ -1,0 +1,50 @@
+<template>
+    <div class="custom-counter-config-editor">
+        <div class="custom-counter-config-editor__toolbar">
+            <ElCheckbox v-model="developerMode">
+                Developer Mode
+            </ElCheckbox>
+        </div>
+
+        <CustomCounterJsonEditor v-if="developerMode" v-model="config" />
+        <CustomCounterRowsEditor v-else v-model="config" />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ElCheckbox } from 'element-plus';
+import type { PropType } from 'vue';
+import { ref } from 'vue';
+
+import CustomCounterJsonEditor from './CustomCounterJsonEditor.vue';
+import CustomCounterRowsEditor from './CustomCounterRowsEditor.vue';
+import type { CustomCounterConfig } from './types';
+
+const config = defineModel({
+    type: Array as PropType<CustomCounterConfig>,
+    required: true,
+});
+
+const developerMode = ref(false);
+</script>
+
+<style scoped>
+.custom-counter-config-editor {
+    display: flex;
+    flex-direction: column;
+    width: 40rem;
+    min-width: min(100%, 40rem);
+    max-height: calc(100vh - 290px);
+    min-height: 0;
+    overflow: hidden;
+}
+
+.custom-counter-config-editor__toolbar {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+</style>

--- a/front_end/src/components/VideoPlayer/CustomCounterJsonEditor.vue
+++ b/front_end/src/components/VideoPlayer/CustomCounterJsonEditor.vue
@@ -1,0 +1,93 @@
+<template>
+    <div class="custom-counter-json-editor">
+        <ElInput
+            v-model="configString"
+            class="custom-counter-json-editor__input"
+            type="textarea"
+            @input="clearConfigError"
+            @change="applyConfigString"
+        />
+        <div v-if="configErrorMessage !== ''" class="custom-counter-json-editor__error">
+            {{ configErrorMessage }}
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ElInput } from 'element-plus';
+import type { PropType } from 'vue';
+import { ref, watch } from 'vue';
+
+import { cloneCustomCounterConfig, isCustomCounterConfig } from './types';
+import type { CustomCounterConfig } from './types';
+
+import { stringifyWithLineWrap } from '@/utils/strings';
+
+const config = defineModel({
+    type: Array as PropType<CustomCounterConfig>,
+    required: true,
+});
+
+const configString = ref('');
+const configErrorMessage = ref('');
+
+watch(config, (value) => {
+    configString.value = stringifyWithLineWrap(value);
+    configErrorMessage.value = '';
+}, { deep: true, immediate: true });
+
+function applyConfigString(value: string) {
+    try {
+        const parsed = JSON.parse(value) as unknown;
+        if (!isCustomCounterConfig(parsed)) {
+            configErrorMessage.value = '配置必须是形如 [["label", "expression"]] 的二维字符串数组。';
+            return;
+        }
+        config.value = cloneCustomCounterConfig(parsed);
+        configErrorMessage.value = '';
+    } catch (error) {
+        configErrorMessage.value = `JSON 解析失败：${formatConfigError(error)}`;
+    }
+}
+
+function clearConfigError() {
+    configErrorMessage.value = '';
+}
+
+function formatConfigError(error: unknown) {
+    if (error instanceof Error && error.message !== '') return error.message;
+    return String(error);
+}
+</script>
+
+<style scoped>
+.custom-counter-json-editor {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.custom-counter-json-editor__input {
+    flex: 1 1 auto;
+    width: 100%;
+    min-height: 0;
+    font-family: "Courier New", Courier, monospace;
+}
+
+:deep(.custom-counter-json-editor__input .el-textarea__inner) {
+    height: 100%;
+    min-height: 0 !important;
+    overflow: auto;
+    resize: none;
+}
+
+.custom-counter-json-editor__error {
+    flex: 0 0 auto;
+    margin-top: 6px;
+    color: var(--el-color-danger);
+    font-size: 12px;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+}
+</style>

--- a/front_end/src/components/VideoPlayer/CustomCounterRowsEditor.vue
+++ b/front_end/src/components/VideoPlayer/CustomCounterRowsEditor.vue
@@ -1,0 +1,195 @@
+<template>
+    <div class="custom-counter-rows-editor">
+        <VueDraggable
+            v-model="draggableRows"
+            class="custom-counter-rows-editor__draggable-rows"
+            handle=".custom-counter-rows-editor__drag-handle"
+            ghost-class="custom-counter-rows-editor__drag-ghost"
+            :animation="150"
+        >
+            <div
+                v-for="(row, index) in draggableRows"
+                :key="`${index}-${row[0]}`"
+                class="custom-counter-rows-editor__row"
+            >
+                <i class="custom-counter-rows-editor__drag-handle pi pi-ellipsis-v" />
+                <ElInput
+                    class="custom-counter-rows-editor__label"
+                    :model-value="row[0]"
+                    size="small"
+                    @input="(value: string) => updateLabel(index, value)"
+                    @change="() => commitRowLabel(index)"
+                />
+                <ElInput
+                    class="custom-counter-rows-editor__expression"
+                    :model-value="row[1]"
+                    size="small"
+                    type="textarea"
+                    :autosize="expressionAutosize"
+                    @input="(value: string) => updateExpression(index, value)"
+                />
+            </div>
+        </VueDraggable>
+        <div class="custom-counter-rows-editor__row">
+            <span class="custom-counter-rows-editor__drag-spacer" />
+            <ElInput
+                v-model="newRowLabel"
+                class="custom-counter-rows-editor__label"
+                size="small"
+                @change="addNewRow"
+            />
+            <ElInput
+                v-model="newRowExpression"
+                class="custom-counter-rows-editor__expression"
+                size="small"
+                type="textarea"
+                :autosize="expressionAutosize"
+                @change="addNewRow"
+            />
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import 'primeicons/primeicons.css';
+
+import { ElInput } from 'element-plus';
+import type { PropType } from 'vue';
+import { computed, ref, watch } from 'vue';
+import { VueDraggable } from 'vue-draggable-plus';
+
+import { cloneCustomCounterConfig } from './types';
+import type { CustomCounterConfig, CustomCounterConfigRow } from './types';
+
+const config = defineModel({
+    type: Array as PropType<CustomCounterConfig>,
+    required: true,
+});
+
+const newRowLabel = ref('');
+const newRowExpression = ref('');
+const editableRows = ref<CustomCounterConfigRow[]>([]);
+const expressionAutosize = { minRows: 1, maxRows: 4 };
+let skipNextEditableRowsSync = false;
+
+const draggableRows = computed<CustomCounterConfigRow[]>({
+    get: () => editableRows.value,
+    set: (nextRows) => {
+        editableRows.value = nextRows;
+        updateConfigFromRows(nextRows);
+    },
+});
+
+watch(config, (value) => {
+    if (skipNextEditableRowsSync) {
+        skipNextEditableRowsSync = false;
+        return;
+    }
+    editableRows.value = cloneCustomCounterConfig(value);
+}, { deep: true, immediate: true });
+
+function addNewRow() {
+    const label = newRowLabel.value.trim();
+    if (label === '') return;
+
+    const nextRows = [
+        ...editableRows.value,
+        [label, newRowExpression.value === '' ? '0' : newRowExpression.value] satisfies CustomCounterConfigRow,
+    ];
+    editableRows.value = nextRows;
+    updateConfigFromRows(nextRows);
+    newRowLabel.value = '';
+    newRowExpression.value = '';
+}
+
+function updateLabel(index: number, label: string) {
+    editableRows.value = editableRows.value.map((row, rowIndex): CustomCounterConfigRow => {
+        return rowIndex === index ? [label, row[1]] : row;
+    });
+}
+
+function commitRowLabel(index: number) {
+    const row = editableRows.value[index];
+
+    const trimmedLabel = row[0].trim();
+    if (trimmedLabel === '') {
+        removeRow(index);
+        return;
+    }
+
+    row[0] = trimmedLabel;
+    updateConfigFromRows(editableRows.value);
+}
+
+function updateExpression(index: number, expression: string) {
+    const nextRows = editableRows.value.map((row, rowIndex): CustomCounterConfigRow => {
+        return rowIndex === index ? [row[0], expression] : row;
+    });
+    editableRows.value = nextRows;
+    updateConfigFromRows(nextRows);
+}
+
+function removeRow(index: number) {
+    const nextRows = editableRows.value.filter((_, rowIndex) => rowIndex !== index);
+    editableRows.value = nextRows;
+    updateConfigFromRows(nextRows);
+}
+
+function updateConfigFromRows(rows: CustomCounterConfigRow[]) {
+    skipNextEditableRowsSync = true;
+    config.value = cloneCustomCounterConfig(rows);
+}
+</script>
+
+<style scoped>
+.custom-counter-rows-editor {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-height: 0;
+    overflow: auto;
+}
+
+.custom-counter-rows-editor__draggable-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.custom-counter-rows-editor__row {
+    display: grid;
+    grid-template-columns: 8px minmax(92px, 0.35fr) minmax(220px, 1fr);
+    gap: 6px;
+    align-items: center;
+}
+
+.custom-counter-rows-editor__drag-handle,
+.custom-counter-rows-editor__drag-spacer {
+    width: 8px;
+}
+
+.custom-counter-rows-editor__drag-handle {
+    color: var(--el-text-color-secondary);
+    cursor: grab;
+    font-size: 14px;
+}
+
+.custom-counter-rows-editor__drag-handle:active {
+    cursor: grabbing;
+}
+
+.custom-counter-rows-editor__drag-ghost {
+    opacity: 0.55;
+}
+
+.custom-counter-rows-editor__label,
+.custom-counter-rows-editor__expression {
+    font-family: "Courier New", Courier, monospace;
+}
+
+:deep(.custom-counter-rows-editor__expression .el-textarea__inner) {
+    resize: none;
+    overflow-wrap: anywhere;
+}
+</style>

--- a/front_end/src/components/VideoPlayer/NativePlayer.cy.ts
+++ b/front_end/src/components/VideoPlayer/NativePlayer.cy.ts
@@ -1,0 +1,78 @@
+import PrimeVue from 'primevue/config';
+
+import NativePlayer from './NativePlayer.vue';
+import { customCounterConfig } from './store';
+import { cloneCustomCounterConfig, defaultCustomCounterConfig } from './types';
+
+import { binaryStringToUint8Array } from '@/../cypress/support/stupidCypress';
+import i18n from '@/i18n';
+
+const fixture = {
+    filename: 'c_10_129.073_24_0.186_Pu Tian Yi(Hu Bei).evf',
+    src: '/native-player-test.evf',
+};
+
+function mountOptions(src: string) {
+    return {
+        props: { src },
+        global: {
+            plugins: [i18n, PrimeVue],
+        },
+    };
+}
+
+function mockVideoFixture() {
+    cy.fixture(fixture.filename, 'binary').then((fileContent) => {
+        const data = binaryStringToUint8Array(fileContent);
+        cy.intercept('GET', fixture.src, {
+            statusCode: 200,
+            headers: { 'content-type': 'application/octet-stream' },
+            body: data,
+        }).as('fetchVideo');
+    });
+}
+
+function dynamicParamCell(label: string, options?: Partial<Cypress.Timeoutable>) {
+    return cy.contains('.custom-counter-wrap th', new RegExp(`^${label}$`), options).parents('tr').find('td');
+}
+
+describe('<NativePlayer />', () => {
+    beforeEach(() => {
+        cy.clearLocalStorage('custom-counter-config');
+        customCounterConfig.value = cloneCustomCounterConfig(defaultCustomCounterConfig);
+    });
+
+    it('loads and renders an EVF replay from fixtures', () => {
+        mockVideoFixture();
+        cy.mount(NativePlayer, mountOptions(fixture.src));
+
+        cy.wait('@fetchVideo');
+        cy.get('.native-player__content').should('be.visible');
+        cy.get('.native-player__board-frame').should('be.visible');
+        cy.get('.custom-counter-wrap').should('be.visible').and('contain', 'cl');
+        dynamicParamCell('column').should('have.text', '8');
+        dynamicParamCell('row').should('have.text', '8');
+        dynamicParamCell('bvs').should('contain', '/24');
+        dynamicParamCell('time').should('contain', '/129.073');
+        cy.get('.custom-counter-wrap').should('be.visible');
+        cy.get('.custom-counter-wrap').should('contain', 'time');
+        cy.get('.custom-counter-wrap').should('contain', 'path');
+    });
+
+    it('advances the replay when playing', () => {
+        mockVideoFixture();
+        cy.mount(NativePlayer, mountOptions(fixture.src));
+
+        cy.wait('@fetchVideo');
+        cy.get('.progress-bar__play').click();
+        dynamicParamCell('time').should(($time) => {
+            expect($time.text()).not.to.equal('0/129.073');
+        });
+        dynamicParamCell('bvs').should(($bvs) => {
+            const match = (/@(\d+)\/(\d+)/).exec($bvs.text());
+            expect(match, $bvs.text()).not.to.equal(null);
+            if (match === null) return;
+            expect(Number(match[1])).to.be.lessThan(Number(match[2]));
+        });
+    });
+});

--- a/front_end/src/components/VideoPlayer/NativePlayer.vue
+++ b/front_end/src/components/VideoPlayer/NativePlayer.vue
@@ -1,0 +1,286 @@
+<template>
+    <div class="native-player">
+        <ElResult v-if="loading" icon="info" :title="t('local.loading')" />
+        <ElResult v-else-if="errorMessage" icon="error" :title="t('local.loadFailed')" :sub-title="errorMessage" />
+        <div v-else-if="video !== null" class="native-player__content">
+            <div class="native-player__stage" :class="{ 'native-player__stage--editing': isEditingCustomCounterConfig }">
+                <CustomCounter :video="video" :current-ms="currentMs" :config="customCounterConfig" />
+
+                <CustomCounterConfigEditor
+                    v-if="isEditingCustomCounterConfig"
+                    v-model="customCounterConfig"
+                    class="native-player__config-editor"
+                />
+                <div v-else class="native-player__board-frame" :class="outerBorderClass">
+                    <div class="native-player__counter-bar" :class="innerBorderClass">
+                        <Counter :value="video.mine_num - video.flag" :digits="3" :size="18" />
+                        <span style="flex-grow: 1" />
+                        <Counter :value="currentMs / 1000" :fixed="3" :digits="3" :size="18" />
+                    </div>
+                    <div class="native-player__board-wrap" :class="innerBorderClass" :style="boardWrapStyle">
+                        <MinesweeperBoard :board="board" :size="boardSize" :cursor-position="cursorPosition" />
+                    </div>
+                </div>
+            </div>
+
+            <div class="native-player__controls">
+                <ProgressBar
+                    v-model="currentMs"
+                    class="native-player__progress"
+                    :duration-ms="durationMs"
+                />
+                <ElCheckbox v-model="isEditingCustomCounterConfig">
+                    {{ t('local.editCounter') }}
+                </ElCheckbox>
+            </div>
+        </div>
+        <ElResult v-else icon="info" :title="t('local.noVideo')" />
+    </div>
+</template>
+
+<script setup lang="ts">
+import '@putianyi888/vue3-minesweeper-board/style.css';
+
+import { Counter, innerBorderClass, MinesweeperBoard, outerBorderClass } from '@putianyi888/vue3-minesweeper-board';
+import { ElCheckbox, ElResult } from 'element-plus';
+import { computed, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import CustomCounter from './CustomCounter.vue';
+import CustomCounterConfigEditor from './CustomCounterConfigEditor.vue';
+import ProgressBar from './ProgressBar.vue';
+import { customCounterConfig } from './store';
+
+import type { AnyVideo } from '@/utils/fileIO';
+import { load_video_file } from '@/utils/fileIO';
+
+const props = defineProps({
+    src: { type: String, default: '' },
+});
+
+const i18nMessages = {
+    'zh-cn': { local: {
+        editCounter: '编辑计数器',
+        loadFailed: '录像加载失败',
+        loading: '正在加载录像',
+        noVideo: '没有录像',
+    } },
+    en: { local: {
+        editCounter: 'Edit counter',
+        loadFailed: 'Failed to load video',
+        loading: 'Loading video',
+        noVideo: 'No video',
+    } },
+};
+
+const { t } = useI18n({ messages: i18nMessages });
+
+const loading = ref(false);
+const errorMessage = ref('');
+const video = shallowRef<AnyVideo | null>(null);
+const board = ref<number[][]>([]);
+const currentMs = ref(0);
+const durationMs = ref(0);
+const isEditingCustomCounterConfig = ref(false);
+const cursor = ref({ x: 0, y: 0 });
+const viewport = ref(readViewportSize());
+
+const boardSize = computed(() => {
+    const column = Math.max(1, video.value?.column ?? 1);
+    const row = Math.max(1, video.value?.row ?? 1);
+    const isStacked = viewport.value.width <= 720;
+    const tableWidth = isStacked ? 0 : 260;
+    const stageGap = isStacked ? 0 : 12;
+    const horizontalChrome = 50 + tableWidth + stageGap + 28;
+    const verticalChrome = 290;
+    const availableWidth = Math.max(1, viewport.value.width * 0.95 - horizontalChrome);
+    const availableHeight = Math.max(1, viewport.value.height - verticalChrome);
+    return Math.max(1, Math.floor(Math.min(28, availableWidth / column, availableHeight / row)));
+});
+
+const boardWrapStyle = computed(() => ({
+    height: `${Math.max(1, video.value?.row ?? 1) * boardSize.value}px`,
+    width: `${Math.max(1, video.value?.column ?? 1) * boardSize.value}px`,
+}));
+
+const cursorPosition = computed(() => {
+    const pixSize = video.value?.pix_size ?? 0;
+    if (pixSize <= 0 || !Number.isFinite(cursor.value.x) || !Number.isFinite(cursor.value.y)) return undefined;
+    return {
+        rowIndex: cursor.value.y / pixSize,
+        columnIndex: cursor.value.x / pixSize,
+    };
+});
+
+let abortController: AbortController | null = null;
+watch(() => props.src, (src) => {
+    void loadVideo(src);
+}, { immediate: true });
+
+watch(currentMs, () => {
+    updateVideoState();
+});
+
+onMounted(() => {
+    window.addEventListener('resize', updateViewportSize);
+});
+
+async function loadVideo(src: string) {
+    cleanupVideo();
+    errorMessage.value = '';
+    board.value = [];
+    currentMs.value = 0;
+    durationMs.value = 0;
+
+    if (src === '') return;
+
+    loading.value = true;
+    abortController?.abort();
+    abortController = new AbortController();
+
+    try {
+        const response = await fetch(src, { signal: abortController.signal });
+        if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+
+        const parsed = load_video_file(await response.arrayBuffer(), filenameFromSrc(src));
+        video.value = parsed;
+        durationMs.value = Math.max(0, Math.trunc(parsed.rtime_ms));
+        currentMs.value = 0;
+        updateVideoState();
+    } catch (error) {
+        if ((error as DOMException).name !== 'AbortError') {
+            errorMessage.value = error instanceof Error ? error.message : String(error);
+        }
+    } finally {
+        loading.value = false;
+    }
+}
+
+function updateVideoState() {
+    const currentVideo = video.value;
+    if (currentVideo === null) return;
+
+    currentVideo.current_time = Math.min(currentMs.value, durationMs.value) / 1000;
+    board.value = normalizeBoard(currentVideo.game_board);
+    cursor.value = { x: currentVideo.x_y.x, y: currentVideo.x_y.y };
+}
+
+function normalizeBoard(value: unknown): number[][] {
+    if (!Array.isArray(value)) return [];
+    return value.map((row) => {
+        return Array.isArray(row) ? row.map((cell) => Number(cell)) : [];
+    });
+}
+
+function filenameFromSrc(src: string) {
+    try {
+        const url = new URL(src, window.location.href);
+        return url.searchParams.get('id') ?? url.pathname.split('/').pop() ?? 'video.avf';
+    } catch {
+        return src.split('/').pop() ?? 'video.avf';
+    }
+}
+
+function cleanupVideo() {
+    video.value?.free();
+    video.value = null;
+}
+
+function readViewportSize() {
+    if (typeof window === 'undefined') return { height: 720, width: 1280 };
+    return { height: window.innerHeight, width: window.innerWidth };
+}
+
+function updateViewportSize() {
+    viewport.value = readViewportSize();
+}
+
+onBeforeUnmount(() => {
+    abortController?.abort();
+    window.removeEventListener('resize', updateViewportSize);
+    cleanupVideo();
+});
+</script>
+
+<style scoped>
+.native-player {
+    min-width: min(92vw, 520px);
+    max-width: calc(95vw - 50px);
+    overflow: hidden;
+}
+
+.native-player__content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+    min-width: 0;
+    max-width: calc(95vw - 50px);
+    max-height: calc(100vh - 170px);
+    overflow: hidden;
+}
+
+.native-player__controls {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+}
+
+.native-player__stage {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+.native-player__stage--editing {
+    align-items: stretch;
+    justify-content: flex-start;
+}
+
+.native-player__board-frame {
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+}
+
+.native-player__counter-bar {
+    display: flex;
+    flex-direction: row;
+    align-self: stretch;
+}
+
+.native-player__board-wrap {
+    position: relative;
+    overflow: hidden;
+    flex: 0 0 auto;
+}
+
+.native-player__config-editor {
+    flex: 0 0 auto;
+    align-self: stretch;
+    max-height: calc(100vh - 290px);
+}
+
+@media (width <= 720px) {
+    .native-player__stage {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .native-player__stage--editing {
+        align-items: flex-start;
+    }
+}
+
+.native-player__progress {
+    flex: 1 1 260px;
+    min-width: 160px;
+}
+</style>

--- a/front_end/src/components/VideoPlayer/ProgressBar.vue
+++ b/front_end/src/components/VideoPlayer/ProgressBar.vue
@@ -1,0 +1,148 @@
+<template>
+    <div class="progress-bar">
+        <ElButton circle :icon="RefreshLeft" :title="t('local.restart')" @click="restart" />
+        <ElButton
+            class="progress-bar__play"
+            circle
+            :icon="isPlaying ? VideoPause : VideoPlay"
+            :title="isPlaying ? t('local.pause') : t('local.play')"
+            @click="togglePlay"
+        />
+        <ElButton :title="t('local.step')" @click="stepForward">
+            +0.1s
+        </ElButton>
+        <ElSlider
+            v-model="currentMs" class="progress-bar__slider" :min="0" :max="durationMs"
+            :step="step" :format-tooltip="formatSeconds" @change="syncPlaybackAnchor"
+        />
+        <ElSelect v-model="playbackRate" class="progress-bar__speed" :title="t('local.speed')">
+            <ElOption v-for="rate in playbackRates" :key="rate" :value="rate" :label="`${rate}x`" />
+        </ElSelect>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { RefreshLeft, VideoPause, VideoPlay } from '@element-plus/icons-vue';
+import { ElButton, ElOption, ElSelect, ElSlider } from 'element-plus';
+import { onBeforeUnmount, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps({
+    durationMs: { type: Number, required: true },
+    step: { type: Number, default: 10 },
+});
+
+const i18nMessages = {
+    'zh-cn': { local: {
+        pause: '暂停',
+        play: '播放',
+        restart: '重新开始',
+        speed: '播放速度',
+        step: '前进 0.1 秒',
+    } },
+    en: { local: {
+        pause: 'Pause',
+        play: 'Play',
+        restart: 'Restart',
+        speed: 'Playback speed',
+        step: 'Step 0.1 seconds',
+    } },
+};
+
+const { t } = useI18n({ messages: i18nMessages });
+
+const playbackRates = [0.5, 1, 1.5, 2, 4];
+
+const currentMs = defineModel<number>({ required: true });
+const isPlaying = ref(false);
+const playbackRate = ref(1);
+
+let animationFrameId = 0;
+let startedAt = 0;
+let startedFrom = 0;
+
+watch(() => props.durationMs, (durationMs) => {
+    currentMs.value = clampTime(currentMs.value, durationMs);
+    if (currentMs.value >= durationMs) stopPlayback();
+});
+
+function formatSeconds(value: number) {
+    return `${(value / 1000).toFixed(2)}s`;
+}
+
+function togglePlay() {
+    if (isPlaying.value) {
+        stopPlayback();
+    } else {
+        startPlayback();
+    }
+}
+
+function startPlayback() {
+    if (props.durationMs <= 0) return;
+    if (currentMs.value >= props.durationMs) currentMs.value = 0;
+    isPlaying.value = true;
+    syncPlaybackAnchor();
+    animationFrameId = requestAnimationFrame(tick);
+}
+
+function stopPlayback() {
+    isPlaying.value = false;
+    if (animationFrameId !== 0) {
+        cancelAnimationFrame(animationFrameId);
+        animationFrameId = 0;
+    }
+}
+
+function tick(now: number) {
+    if (!isPlaying.value) return;
+
+    currentMs.value = clampTime(startedFrom + (now - startedAt) * playbackRate.value, props.durationMs);
+    if (currentMs.value >= props.durationMs) {
+        stopPlayback();
+        return;
+    }
+    animationFrameId = requestAnimationFrame(tick);
+}
+
+function restart() {
+    stopPlayback();
+    currentMs.value = 0;
+}
+
+function stepForward() {
+    stopPlayback();
+    currentMs.value = clampTime(currentMs.value + 100, props.durationMs);
+}
+
+function syncPlaybackAnchor() {
+    startedAt = performance.now();
+    startedFrom = currentMs.value;
+}
+
+function clampTime(value: number, durationMs: number) {
+    return Math.min(Math.max(0, value), Math.max(0, durationMs));
+}
+
+onBeforeUnmount(() => {
+    stopPlayback();
+});
+</script>
+
+<style scoped>
+.progress-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+}
+
+.progress-bar__slider {
+    flex: 1 1 260px;
+    min-width: 160px;
+}
+
+.progress-bar__speed {
+    width: 86px;
+}
+</style>

--- a/front_end/src/components/VideoPlayer/store.ts
+++ b/front_end/src/components/VideoPlayer/store.ts
@@ -1,0 +1,16 @@
+import { useLocalStorage } from '@vueuse/core';
+import type { Ref } from 'vue';
+
+import { cloneCustomCounterConfig, defaultCustomCounterConfig, isCustomCounterConfig } from './types';
+import type { CustomCounterConfig } from './types';
+
+const storedCustomCounterConfig = useLocalStorage<unknown>(
+    'custom-counter-config',
+    cloneCustomCounterConfig(defaultCustomCounterConfig),
+);
+
+if (!isCustomCounterConfig(storedCustomCounterConfig.value)) {
+    storedCustomCounterConfig.value = cloneCustomCounterConfig(defaultCustomCounterConfig);
+}
+
+export const customCounterConfig = storedCustomCounterConfig as Ref<CustomCounterConfig>;

--- a/front_end/src/components/VideoPlayer/types.ts
+++ b/front_end/src/components/VideoPlayer/types.ts
@@ -1,0 +1,113 @@
+import type { AnyVideo } from '@/utils/fileIO';
+
+export const videoNumericParamKeys = [
+    'bbbv',
+    'bbbv_s',
+    'bbbv_solved',
+    'ce',
+    'ce_s',
+    'cell0',
+    'cell1',
+    'cell2',
+    'cell3',
+    'cell4',
+    'cell5',
+    'cell6',
+    'cell7',
+    'cell8',
+    'cl',
+    'cl_s',
+    'column',
+    'corr',
+    'current_event_id',
+    'dce',
+    'double',
+    'double_s',
+    'etime',
+    'flag',
+    'flag_s',
+    'game_board_state',
+    'hzini',
+    'ioe',
+    'isl',
+    'lce',
+    'left',
+    'left_s',
+    'level',
+    'mine_num',
+    'mode',
+    'mouse_state',
+    'op',
+    'path',
+    'pix_size',
+    'pluck',
+    'rce',
+    'right',
+    'right_s',
+    'row',
+    'rqp',
+    'rtime',
+    'rtime_ms',
+    'stnb',
+    'thrp',
+    'video_end_time',
+    'video_start_time',
+    'zini',
+] as const satisfies readonly (keyof AnyVideo)[];
+
+export type VideoNumericParamKey = typeof videoNumericParamKeys[number];
+
+export type CustomCounterConfigRow = [label: string, expression: string];
+
+export type CustomCounterConfig = CustomCounterConfigRow[];
+
+export const defaultCustomCounterConfig: CustomCounterConfig = [
+    ['time', 'roundTo(rtime, 3) || "/" || roundTo(etime, 3)'],
+    ['bvs', 'roundTo(bbbv_s, 3) || "@" || bbbv_solved || "/" || bbbv'],
+    ['cl', 'cl || "=" || left || "+" || right || "+" || double'],
+    ['cls', 'roundTo(cl_s, 3) || "=" || roundTo(left_s, 3) || "+" || roundTo(right_s, 3) || "+" || roundTo(double_s, 3)'],
+    ['ce', 'ce || "=" || lce || "+" || rce || "+" || dce'],
+    ['cell0-2', 'cell0 || "/" || cell1 || "/" || cell2'],
+    ['cell3-5', 'cell3 || "/" || cell4 || "/" || cell5'],
+    ['cell6-8', 'cell6 || "/" || cell7 || "/" || cell8'],
+    ['column', 'column'],
+    ['corr', 'corr'],
+    ['current_event_id', 'current_event_id'],
+    ['flag', 'flag'],
+    ['flag_s', 'flag_s'],
+    ['game_board_state', 'game_board_state'],
+    ['hzini', 'hzini'],
+    ['ioe', 'ioe'],
+    ['isl', 'isl'],
+    ['level', 'level'],
+    ['mine_num', 'mine_num'],
+    ['mode', 'mode'],
+    ['mouse_state', 'mouse_state'],
+    ['op', 'op'],
+    ['path', 'path'],
+    ['pix_size', 'pix_size'],
+    ['pluck', 'pluck'],
+    ['row', 'row'],
+    ['rqp', 'rqp'],
+    ['rtime_ms', 'rtime_ms'],
+    ['stnb', 'stnb'],
+    ['thrp', 'thrp'],
+    ['video_end_time', 'video_end_time'],
+    ['video_start_time', 'video_start_time'],
+    ['zini', 'zini'],
+];
+
+export function cloneCustomCounterConfig(config: CustomCounterConfig): CustomCounterConfig {
+    return config.map(([label, expression]) => [label, expression]);
+}
+
+export function isCustomCounterConfig(value: unknown): value is CustomCounterConfig {
+    return Array.isArray(value) && value.every((row) => isCustomCounterConfigRow(row));
+}
+
+export function isCustomCounterConfigRow(value: unknown): value is CustomCounterConfigRow {
+    return Array.isArray(value)
+        && value.length === 2
+        && typeof value[0] === 'string'
+        && typeof value[1] === 'string';
+}

--- a/front_end/src/store/index.ts
+++ b/front_end/src/store/index.ts
@@ -85,7 +85,7 @@ export const local = useLocalStorage(
 export const videoPlayerConfig = useLocalStorage(
     'video-player-config',
     {
-        backend: 'flop' as 'flop' | 'StrangeDust',
+        backend: 'native' as 'native' | 'flop' | 'StrangeDust',
         strangeDustTrust: false,
     },
     { mergeDefaults: true },

--- a/front_end/src/utils/strings.test.ts
+++ b/front_end/src/utils/strings.test.ts
@@ -24,6 +24,14 @@ describe('strings', () => {
     "gamma"]
 }`);
         });
+
+        it('Keeps long first array item valid', () => {
+            expect(stringifyWithLineWrap([['long-label', 'long-expression']], 16, 2)).toBe('[["long-label","long-expression"]]');
+        });
+
+        it('Keeps empty arrays valid', () => {
+            expect(stringifyWithLineWrap([], 16, 2)).toBe('[]');
+        });
     });
 
     describe('countRows', () => {

--- a/front_end/src/utils/strings.ts
+++ b/front_end/src/utils/strings.ts
@@ -16,11 +16,13 @@ export function stringifyWithLineWrap(
 
     function processValue(value: any, currentIndent: string): string {
         if (Array.isArray(value)) {
+            if (value.length === 0) return '[]';
+
             let line = '[';
             const lines: string[] = [];
             for (const v of value) {
                 const itemStr = JSON.stringify(v);
-                if (line.length + itemStr.length + 2 > maxLineLength) {
+                if (line !== '[' && line.length + itemStr.length + 2 > maxLineLength) {
                     lines.push(line.trimEnd() + ',');
                     line = currentIndent + INDENTATION + itemStr;
                 } else {


### PR DESCRIPTION
- Implement a new NativePlayer component with support for customizable counter displays showing video parameters.
- Includes progress bar controls, board rendering, and configuration editor with both UI and JSON modes.
- Sets native as the default video backend.