### PR TITLE
Add player main settings and probability display

### DIFF
--- a/front_end/package.json
+++ b/front_end/package.json
@@ -22,7 +22,7 @@
     "@mdit/plugin-img-lazyload": "1.0.1",
     "@mdit/plugin-mathjax": "1.1.0",
     "@primeuix/themes": "2.0.3",
-    "@putianyi888/vue3-minesweeper-board": "0.3.0",
+    "@putianyi888/vue3-minesweeper-board": "0.4.0",
     "@putianyi888/vue3-plots": "0.6.0",
     "@unicode/unicode-16.0.0": "1.6.17",
     "@vueuse/components": "14.3.0",

--- a/front_end/src/components/VideoPlayer/NativePlayer.cy.ts
+++ b/front_end/src/components/VideoPlayer/NativePlayer.cy.ts
@@ -60,6 +60,11 @@ describe('<NativePlayer />', () => {
         videoPlayerConfig.value = {
             backend: 'native',
             cellSize: 16,
+            showProbability: true,
+            probabilityColorScheme: {
+                colors: ['#15803d', '#0f766e', '#2563eb', '#b45309', '#dc2626', '#7f1d1d'],
+                thresholds: [10, 25, 50, 75, 90],
+            },
             strangeDustTrust: false,
         };
     });

--- a/front_end/src/components/VideoPlayer/NativePlayer.vue
+++ b/front_end/src/components/VideoPlayer/NativePlayer.vue
@@ -3,8 +3,14 @@
         <ElResult v-if="loading" icon="info" :title="t('local.loading')" />
         <ElResult v-else-if="errorMessage" icon="error" :title="t('local.loadFailed')" :sub-title="errorMessage" />
         <div v-else-if="video !== null" class="native-player__content">
-            <div class="native-player__stage" :class="{ 'native-player__stage--editing': isEditingCustomCounterConfig }">
+            <div class="native-player__stage" :class="{ 'native-player__stage--editing': isEditingConfig }">
+                <PlayerMainSettings
+                    v-if="isEditingPlayerMainConfig"
+                    v-model="videoPlayerConfig"
+                    class="native-player__player-main-settings"
+                />
                 <CustomCounter
+                    v-else
                     class="native-player__custom-counter"
                     :video="video"
                     :current-ms="currentMs"
@@ -18,10 +24,12 @@
                 />
                 <PlayerMain
                     v-else
-                    v-model:board-size="videoPlayerConfig.cellSize"
                     :video="video"
                     :current-ms="currentMs"
                     :cursor-position="cursorPosition"
+                    :show-probability="videoPlayerConfig.showProbability"
+                    :size="videoPlayerConfig.cellSize"
+                    :probability-color-scheme-config="PiecewiseColorScheme.createFromTheme(videoPlayerConfig.probabilityColorScheme)"
                 />
             </div>
 
@@ -33,6 +41,9 @@
                 />
                 <ElCheckbox v-model="isEditingCustomCounterConfig">
                     {{ t('local.editCounter') }}
+                </ElCheckbox>
+                <ElCheckbox v-model="isEditingPlayerMainConfig">
+                    {{ t('local.editPlayerMain') }}
                 </ElCheckbox>
             </div>
         </div>
@@ -49,11 +60,13 @@ import { useI18n } from 'vue-i18n';
 import CustomCounter from './CustomCounter.vue';
 import CustomCounterSettings from './CustomCounterSettings.vue';
 import PlayerMain from './PlayerMain.vue';
+import PlayerMainSettings from './PlayerMainSettings.vue';
 import ProgressBar from './ProgressBar.vue';
 import { customCounterConfig } from './store';
 
 import $axios from '@/http';
 import { videoPlayerConfig } from '@/store';
+import { PiecewiseColorScheme } from '@/utils/colors';
 import type { AnyVideo } from '@/utils/fileIO';
 import { load_video_file } from '@/utils/fileIO';
 
@@ -64,12 +77,14 @@ const props = defineProps({
 const i18nMessages = {
     'zh-cn': { local: {
         editCounter: '编辑计数器',
+        editPlayerMain: '主面板设置',
         loadFailed: '录像加载失败',
         loading: '正在加载录像',
         noVideo: '没有录像',
     } },
     en: { local: {
         editCounter: 'Edit counter',
+        editPlayerMain: 'Main settings',
         loadFailed: 'Failed to load video',
         loading: 'Loading video',
         noVideo: 'No video',
@@ -84,7 +99,10 @@ const video = shallowRef<AnyVideo | null>(null);
 const currentMs = ref(0);
 const durationMs = ref(0);
 const isEditingCustomCounterConfig = ref(false);
+const isEditingPlayerMainConfig = ref(false);
 const cursor = ref({ x: 0, y: 0 });
+
+const isEditingConfig = computed(() => isEditingCustomCounterConfig.value || isEditingPlayerMainConfig.value);
 
 const cursorPosition = computed(() => {
     const pixSize = video.value?.pix_size ?? 0;
@@ -217,6 +235,10 @@ onBeforeUnmount(() => {
 }
 
 .native-player__stage--editing .native-player__custom-counter {
+    align-self: center;
+}
+
+.native-player__player-main-settings {
     align-self: center;
 }
 

--- a/front_end/src/components/VideoPlayer/PlayerMain.vue
+++ b/front_end/src/components/VideoPlayer/PlayerMain.vue
@@ -3,17 +3,14 @@
         <div class="player-main__counter-bar" :class="innerBorderClass">
             <Counter :value="video.mine_num - video.flag" :digits="3" :size="18" />
             <span class="player-main__counter-spacer" />
-            <InputNumber
-                v-model="boardSize"
-                class="player-main__size-input"
-                :min="1" :max="48"
-                :title="t('local.size')"
-            />
-            <span class="player-main__counter-spacer" />
             <Counter :value="currentMs / 1000" :fixed="3" :digits="3" :size="18" />
         </div>
         <div :class="innerBorderClass">
-            <MinesweeperBoard :board="video.game_board" :size="boardSize" :cursor-position="cursorPosition" />
+            <MinesweeperBoard :board="video.game_board" :size="size" :cursor-position="cursorPosition">
+                <template v-if="showProbability" #default>
+                    <BoardProbability :board="probabilityBoard" :color="probabilityColor" />
+                </template>
+            </MinesweeperBoard>
         </div>
     </div>
 </template>
@@ -21,11 +18,11 @@
 <script setup lang="ts">
 import '@putianyi888/vue3-minesweeper-board/style.css';
 
-import { Counter, innerBorderClass, MinesweeperBoard, outerBorderClass } from '@putianyi888/vue3-minesweeper-board';
+import { BoardProbability, Counter, innerBorderClass, MinesweeperBoard, outerBorderClass } from '@putianyi888/vue3-minesweeper-board';
 import type { PropType } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { computed } from 'vue';
 
-import InputNumber from '@/components/common/InputNumber.vue';
+import { PiecewiseColorScheme } from '@/utils/colors';
 import type { AnyVideo } from '@/utils/fileIO';
 
 interface CursorPosition {
@@ -33,24 +30,26 @@ interface CursorPosition {
     columnIndex: number;
 }
 
-defineProps({
+const props = defineProps({
     video: { type: Object as PropType<AnyVideo>, required: true },
     currentMs: { type: Number, required: true },
     cursorPosition: { type: Object as PropType<CursorPosition>, default: undefined },
+    showProbability: { type: Boolean, default: true },
+    size: { type: Number, default: 24 },
+    probabilityColorScheme: {
+        type: PiecewiseColorScheme,
+        default: () => new PiecewiseColorScheme([], []),
+    },
 });
 
-const boardSize = defineModel<number>('boardSize', { default: 16 });
+const probabilityBoard = computed(() => {
+    void props.currentMs;
+    return props.video.game_board_poss as number[][];
+});
 
-const i18nMessages = {
-    'zh-cn': { local: {
-        size: '格子边长',
-    } },
-    en: { local: {
-        size: 'Cell size',
-    } },
-};
-
-const { t } = useI18n({ messages: i18nMessages });
+function probabilityColor(value: number) {
+    return props.probabilityColorScheme.getColor(value * 100);
+}
 </script>
 
 <style scoped>
@@ -71,9 +70,5 @@ const { t } = useI18n({ messages: i18nMessages });
 .player-main__counter-spacer {
     flex: 1 1 0;
     min-width: 0;
-}
-
-.player-main__size-input {
-    width: 44px;
 }
 </style>

--- a/front_end/src/components/VideoPlayer/PlayerMainSettings.vue
+++ b/front_end/src/components/VideoPlayer/PlayerMainSettings.vue
@@ -1,0 +1,88 @@
+<template>
+    <div class="player-main-settings">
+        <label class="player-main-settings__row">
+            <span class="text">{{ t('local.cellSize') }}</span>
+            <InputNumber
+                v-model="config.cellSize"
+                class="player-main-settings__number-input"
+                :min="1" :max="48"
+            />
+        </label>
+        <ElCheckbox v-model="config.showProbability">
+            <span class="text">
+                {{ t('local.showProbability') }}
+            </span>
+        </ElCheckbox>
+        <div v-if="config.showProbability" class="player-main-settings__color-scheme">
+            <ColorSchemeSetting v-model="config.probabilityColorScheme" />
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import '@/styles/text.css';
+
+import { ElCheckbox } from 'element-plus';
+import type { PropType } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import InputNumber from '@/components/common/InputNumber.vue';
+import ColorSchemeSetting from '@/components/visualization/ColorSchemeSetting.vue';
+import type { PiecewiseColorSchemeInterface } from '@/utils/colors';
+
+interface PlayerMainConfig {
+    cellSize: number;
+    probabilityColorScheme: PiecewiseColorSchemeInterface;
+    showProbability: boolean;
+}
+
+const config = defineModel({
+    type: Object as PropType<PlayerMainConfig>,
+    required: true,
+});
+
+const i18nMessages = {
+    'zh-cn': { local: {
+        cellSize: '格子边长',
+        showProbability: '显示概率',
+    } },
+    en: { local: {
+        cellSize: 'Cell Size',
+        showProbability: 'Show Probability',
+    } },
+};
+
+const { t } = useI18n({ messages: i18nMessages });
+</script>
+
+<style scoped>
+.player-main-settings {
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+    gap: 10px;
+    width: 20rem;
+    min-width: min(25%, 20rem);
+    max-height: calc(100vh - 290px);
+    padding: 6px 0;
+    overflow: auto;
+}
+
+.player-main-settings__row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    white-space: nowrap;
+}
+
+.player-main-settings__number-input {
+    width: 48px;
+}
+
+.player-main-settings__color-scheme {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+}
+</style>

--- a/front_end/src/components/visualization/ColorSchemeSetting.vue
+++ b/front_end/src/components/visualization/ColorSchemeSetting.vue
@@ -3,42 +3,34 @@
         <ElColorPicker v-model="colorScheme.colors[0]" show-alpha />
         <template v-for="(item, index) in colorScheme.thresholds" :key="index">
             <span>&lt;</span>
-            <ElInputNumber v-model="colorScheme.thresholds[index]" :min="index == 0 ? -Infinity : colorScheme.thresholds[index-1]" :max="index == colorScheme.thresholds.length-1 ? Infinity : colorScheme.thresholds[index+1]" :controls="false" size="small" style="width:50px; display: inline-block" />
+            <InputNumber v-model="colorScheme.thresholds[index]" :min="index == 0 ? -Infinity : colorScheme.thresholds[index-1]" :max="index == colorScheme.thresholds.length-1 ? Infinity : colorScheme.thresholds[index+1]" style="field-sizing: content;" />
             <span>&lt;</span>
             <ElColorPicker v-model="colorScheme.colors[index+1]" show-alpha />
         </template>
         <span style="flex-grow: 1" />
-        <div>
-            增删节点
-            &nbsp;
-            <ElInputNumber v-model="operationNode" :controls="false" style="width: 40px" />
-            &nbsp;
-            <ElTooltip content="Add">
-                <ElLink underline="never">
-                    <BaseIconAdd />
-                </ElLink>
-            </ElTooltip>
-            &nbsp;
-            <ElTooltip content="Merge to left">
-                <ElLink underline="never">
+        <div style="display: flex; flex-direction: row; gap: 0.25em; align-items: center; margin-left: 0.25em; margin-right: 0.25em">
+            <span>{{ t('local.chooseNode') }}</span>
+            <InputNumber v-model="operationNode" style="field-sizing: content;" />
+            <div v-if="colorScheme.thresholds.includes(operationNode)" style="display: flex; margin-left: 0.25em;">
+                <ElLink underline="never" :title="t('local.mergeLeft')">
                     <ElIcon size="large">
                         <ArrowLeft />
                     </ElIcon>
                 </ElLink>
-            </ElTooltip>
-            &nbsp;
-            <ElTooltip content="Merge to right">
-                <ElLink underline="never">
+                <BaseIconDelete />
+                <ElLink underline="never" :title="t('local.mergeRight')">
                     <ElIcon size="large">
                         <ArrowRight />
                     </ElIcon>
                 </ElLink>
-            </ElTooltip>
-            &nbsp;
-            <ElCheckbox v-model="developerMode">
-                Developer Mode
-            </ElCheckbox>
+            </div>
+            <ElLink v-else underline="never" :title="t('local.addNode')">
+                <BaseIconAdd />
+            </ElLink>
         </div>
+        <ElCheckbox v-model="developerMode" size="small" style="margin-left: 0.5em">
+            {{ t('local.developerMode') }}
+        </ElCheckbox>
     </div>
     <div v-if="developerMode">
         <ElInput v-model="colorSchemeString" type="textarea" :rows="countRows(colorSchemeString)" style="font-family: 'Courier New', Courier, monospace;" @change="(value: string) => {colorScheme = JSON.parse(value)}" />
@@ -46,20 +38,18 @@
 </template>
 
 <script setup lang="ts">
-import { ElCheckbox, ElColorPicker, ElIcon, ElInput, ElInputNumber, ElLink, ElTooltip } from 'element-plus';
+import { ElCheckbox, ElColorPicker, ElIcon, ElInput, ElLink } from 'element-plus';
 import type { PropType } from 'vue';
 import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-import { BaseIconAdd } from '@/components/common/icon';
+import { BaseIconAdd, BaseIconDelete } from '@/components/common/icon';
+import InputNumber from '@/components/common/InputNumber.vue';
+import type { PiecewiseColorSchemeInterface } from '@/utils/colors';
 import { countRows, stringifyWithLineWrap } from '@/utils/strings';
 
-interface ColorScheme {
-    colors: string[];
-    thresholds: number[];
-}
-
 const colorScheme = defineModel({
-    type: Object as PropType<ColorScheme>,
+    type: Object as PropType<PiecewiseColorSchemeInterface>,
     required: true,
 });
 
@@ -70,6 +60,25 @@ const colorSchemeString = ref('');
 watch(colorScheme.value, (value) => {
     colorSchemeString.value = stringifyWithLineWrap(value);
 }, { immediate: true });
+
+const i18nMessages = {
+    'zh-cn': { local: {
+        addNode: '添加',
+        chooseNode: '选择节点',
+        developerMode: '开发者模式',
+        mergeLeft: '删除（向左合并）',
+        mergeRight: '删除（向右合并）',
+    } },
+    en: { local: {
+        addNode: 'Add',
+        chooseNode: 'Choose a node',
+        developerMode: 'Developer Mode',
+        mergeLeft: 'Delete (merge left)',
+        mergeRight: 'Delete (merge right)',
+    } },
+};
+
+const { t } = useI18n({ messages: i18nMessages });
 </script>
 
 <style lang="less" scoped>

--- a/front_end/src/store/index.ts
+++ b/front_end/src/store/index.ts
@@ -87,6 +87,11 @@ export const videoPlayerConfig = useLocalStorage(
     {
         backend: 'native' as 'native' | 'flop' | 'StrangeDust',
         cellSize: 24,
+        showProbability: true,
+        probabilityColorScheme: {
+            colors: ['#15803d', '#0f766e', '#2563eb', '#b45309', '#dc2626', '#7f1d1d'],
+            thresholds: [10, 25, 50, 75, 90],
+        },
         strangeDustTrust: false,
     },
     { mergeDefaults: true },

--- a/front_end/src/utils/colors.ts
+++ b/front_end/src/utils/colors.ts
@@ -1,6 +1,6 @@
 import { ArrayUtils } from './arrays';
 
-interface Theme {
+export interface PiecewiseColorSchemeInterface {
     thresholds: number[];
     colors: string[];
 }
@@ -49,7 +49,7 @@ export class PiecewiseColorScheme {
         }
     }
 
-    public static createFromTheme(theme: Theme): PiecewiseColorScheme {
+    public static createFromTheme(theme: PiecewiseColorSchemeInterface): PiecewiseColorScheme {
         return new PiecewiseColorScheme(theme.colors, theme.thresholds);
     }
 


### PR DESCRIPTION
- Add `PlayerMainSettings` component and integrate probability overlay into `PlayerMain/NativePlayer`.
- Expose `showProbability`, `size` and `probabilityColorScheme` props; wire `PiecewiseColorScheme.createFromTheme` and export the color scheme interface.
- Update `ColorSchemeSetting` UI, i18n strings and developer controls.
- Add default probability color scheme to store.
- Bump `@putianyi888/vue3-minesweeper-board` to 0.4.0.
- Minor template/prop refactors to support the new settings and behavior.