### PR TITLE
Configure static gzip compression for assets

### DIFF
--- a/back_end/saolei/default.conf
+++ b/back_end/saolei/default.conf
@@ -27,6 +27,12 @@ server {
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_prefer_server_ciphers on;
 
+    # front_end/vite.config.ts uses Vite's default base "/".
+    # Build assets are requested as /assets/..., and vite-plugin-compression
+    # writes .gz files next to .js/.mjs/.json/.css/.html in dist.
+    gzip_static on;
+    gzip_vary on;
+
     # VitePress 用户指南
     # 将 vitepress_doc/.vitepress/dist 的构建产物部署到 /root/saolei/docs/
     location ^~ /docs/ {
@@ -58,13 +64,13 @@ server {
 	
 	# 修改3：
 	# 当访问路径为/static时Nginx将会自行处理
-	# 这里的/root/saolei_static/static路径为静态资源存储地址
-	# 注意：该路径与前面Django的settings.py文件里设置的一致
-    location /static {
+    # 这里的/root/saolei_static/static路径为静态资源存储地址
+    # 注意：该路径与前面Django的settings.py文件里设置的一致
+    location ^~ /static/ {
         expires 30d;
         autoindex on;
         add_header Cache-Control private;
-        alias /root/saolei/static;
+        alias /root/saolei/static/;
     }
 
     # 下载阿比特和元扫雷等
@@ -76,7 +82,7 @@ server {
     }
 
     # 确保把wasm当作静态资源
-    location ~* \.(html|css|gif|ico|jpg|js|png|ttf|woff|wasm|svg)$ {
+    location ~* \.(html|css|gif|ico|jpg|js|json|mjs|png|ttf|woff|wasm|svg)$ {
         root /root/saolei/static;
     }
 }

--- a/back_end/saolei/nginx.conf
+++ b/back_end/saolei/nginx.conf
@@ -47,14 +47,8 @@ http {
 	# Gzip Settings
 	##
 
-	gzip on;
-
-	# gzip_vary on;
-	# gzip_proxied any;
-	# gzip_comp_level 6;
-	# gzip_buffers 16 8k;
-	# gzip_http_version 1.1;
-	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+	# Pre-compressed frontend assets are served by conf.d/default.conf
+	# with gzip_static. Dynamic gzip is intentionally not enabled globally.
 
 	##
 	# Virtual Host Configs


### PR DESCRIPTION
- Enable serving pre-compressed frontend assets generated by vite-plugin-compression.
- Replace dynamic gzip with gzip_static on the server-side.
- Update static file location with proper trailing slashes and add json/mjs MIME types for Vite-built assets.