### PR TITLE
Improve user video reload test with tab navigation

### DIFF
--- a/front_end/cypress/e2e/bugfix/user-video.cy.ts
+++ b/front_end/cypress/e2e/bugfix/user-video.cy.ts
@@ -26,6 +26,17 @@ function navigateHash(hash: string) {
     cy.location('hash').should('eq', hash);
 }
 
+function navigateToUserTab(tab: string) {
+    navigateHash(`#/player/${USER.id}/${tab}`);
+    cy.get('.personal-homepage').should('be.visible');
+    cy.get('.personal-homepage .el-tabs__item.is-active').should('have.attr', 'aria-controls', `pane-${tab}`);
+}
+
+function navigateAwayFromUserPage() {
+    navigateHash('#/settings');
+    cy.get('.personal-homepage').should('not.exist');
+}
+
 function waitForVideoList(count: number) {
     cy.wait('@getUserVideos').its('response.body').should((videos) => {
         expect(videos).to.have.length(count);
@@ -40,24 +51,43 @@ describe('User Videos', () => {
     });
 
     it('Reloads videos created outside the current page when revisiting the same own user page', () => {
-        cy.intercept({ method: 'GET', pathname: '/api/userprofile/videolist' }).as('getUserVideos');
+        let videoListRequestCount = 0;
+        cy.intercept({ method: 'GET', pathname: '/api/userprofile/videolist' }, (request) => {
+            videoListRequestCount += 1;
+            request.continue();
+        }).as('getUserVideos');
         cy.login(USER.username, USER.password);
 
         cy.visitUser(USER.id, 'videos');
         waitForVideoList(1);
+        cy.wrap(null).should(() => {
+            expect(videoListRequestCount).to.equal(1);
+        });
         cy.contains(USER.username).should('be.visible');
         cy.get('table:visible').should('contain', '31.000');
         cy.get('table:visible').getTable().should((tableData) => {
             expect(tableData.length).to.equal(1);
         });
 
-        navigateHash('#/settings');
-
         // Simulate a video created outside this frontend page. UI uploads update user.videos directly.
         createVideo(22000);
 
-        navigateHash(`#/player/${USER.id}/videos`);
+        navigateToUserTab('summary');
+        navigateToUserTab('videos');
+        cy.wrap(null).should(() => {
+            expect(videoListRequestCount).to.equal(1);
+        });
+        cy.get('table:visible').should('not.contain', '22.000');
+        cy.get('table:visible').getTable().should((tableData) => {
+            expect(tableData.length).to.equal(1);
+        });
+
+        navigateAwayFromUserPage();
+        navigateToUserTab('videos');
         waitForVideoList(2);
+        cy.wrap(null).should(() => {
+            expect(videoListRequestCount).to.equal(2);
+        });
         cy.get('table:visible').should('contain', '22.000');
         cy.get('table:visible').getTable().should((tableData) => {
             expect(tableData.length).to.equal(2);


### PR DESCRIPTION
Add helper functions for navigating user tabs and away from user page. Enhance test to verify video list is cached when navigating between tabs but reloaded when returning after leaving the user page. Track API request counts to validate caching behavior.