### PR TITLE
Improve Cypress account-link test assertions

### DIFF
--- a/front_end/cypress/e2e/accountlink.cy.ts
+++ b/front_end/cypress/e2e/accountlink.cy.ts
@@ -71,7 +71,7 @@ function expectAccountLinkTableRow(platform: string, identifier: string, verifie
     cy.get('table:visible').getTable().should((tableData) => {
         const row = tableData.find((item) => item['Platform ID'] === identifier);
 
-        expect(row).to.deep.equal({
+        expect(row, `account link row for ${platform} #${identifier}`).to.deep.equal({
             'User ID': `${USER.id}`,
             Platform: platform,
             'Platform ID': identifier,
@@ -99,11 +99,13 @@ function staffVerifyAccount(platform: string, identifier: string) {
     visitStaffAccountLink();
     expectAccountLinkTableRow(platform, identifier, false);
 
+    cy.intercept('POST', '**/accountlink/verify/').as('verifyAccountLink');
     cy.contains(':visible', 'ID').first().next().find('input').type(`${USER.id}{enter}`);
     cy.contains('平台').next().contains('Select').click();
     cy.get('li').contains(platform).click();
     cy.contains('平台ID').next().find('input').type(`${identifier}{enter}`);
     cy.contains(/^\s*绑定\s*$/).click();
+    cy.wait('@verifyAccountLink').its('response.statusCode').should('eq', 200);
     cy.wait('@accountLinkQueue');
 
     expectAccountLinkTableRow(platform, identifier, true);


### PR DESCRIPTION
Add a clearer assertion message for account link table row failures and introduce an intercept+wait for the `POST **/accountlink/verify/**` request, asserting a 200 response. These changes make the e2e test more robust and easier to debug when verification fails.