### PR TITLE
Migrate log streaming from SSE to polling

### DIFF
--- a/back_end/saolei/common/api.py
+++ b/back_end/saolei/common/api.py
@@ -1,14 +1,12 @@
 
 
 from datetime import datetime, timezone
-import json
 import os
 from pathlib import Path
-import time
 
 from django.core.cache import cache
 from django.db.models import Sum
-from django.http import FileResponse, Http404, StreamingHttpResponse
+from django.http import FileResponse, Http404
 from django.utils import timezone as django_timezone
 from django_tasks import TaskResultStatus
 from django_tasks_db.models import DBTaskResult
@@ -29,7 +27,6 @@ router = Router()
 LOG_DIR = Path('logs')
 DEFAULT_TAIL_BYTES = 64 * 1024
 MAX_TAIL_BYTES = 1024 * 1024
-LOG_STREAM_POLL_INTERVAL = 1
 
 
 class LogFileOut(Schema):
@@ -43,6 +40,13 @@ class LogTailOut(Schema):
     offset: int
     size: int
     truncated: bool
+
+
+class LogPollOut(Schema):
+    content: str
+    offset: int
+    size: int
+    status: str
 
 
 def _get_log_path(filename: str) -> Path:
@@ -156,7 +160,7 @@ def list_logs(request):
         file_stats.append({
             'name': file,
             'size': file_stat.st_size,
-            'mtime': datetime.fromtimestamp(file_stat.st_ctime, tz=timezone.utc),
+            'mtime': datetime.fromtimestamp(file_stat.st_mtime, tz=timezone.utc),
         })
     return file_stats
 
@@ -193,40 +197,56 @@ def get_log_tail(request, filename: str, tail_bytes: int = DEFAULT_TAIL_BYTES):
     }
 
 
-@router.get('/staff/logstream')
+@router.get('/staff/logpoll', response=LogPollOut)
 @decorate_view(staff_required)
-def stream_log_tail(request, filename: str, offset: int = 0, tail_bytes: int = DEFAULT_TAIL_BYTES):
+def poll_log_tail(request, filename: str, offset: int = 0, tail_bytes: int = DEFAULT_TAIL_BYTES):
     """
     - staff_required
 
-    Stream appended log content as Server-Sent Events from the given byte offset.
+    Return appended log content from the given byte offset without holding a long-lived connection.
     """
-    log_path = _get_log_path(filename)
+    if Path(filename).name != filename:
+        raise Http404()
+
+    log_dir = LOG_DIR.resolve()
+    log_path = (log_dir / filename).resolve()
+    if log_path.parent != log_dir:
+        raise Http404()
+
     clamped_tail_bytes = _clamp_tail_bytes(tail_bytes)
-
-    def event_stream():
-        current_offset = max(offset, 0)
-        while True:
-            try:
-                file_size = log_path.stat().st_size
-                if file_size < current_offset:
-                    current_offset = max(file_size - clamped_tail_bytes, 0)
-                    yield 'event: reset\ndata: {}\n\n'
-                if file_size > current_offset:
-                    content, current_offset = _read_from_offset(log_path, current_offset)
-                    yield f'data: {json.dumps({"content": content, "offset": current_offset})}\n\n'
-                else:
-                    yield ': keep-alive\n\n'
-            except FileNotFoundError:
-                yield 'event: deleted\ndata: {}\n\n'
-                return
-            time.sleep(LOG_STREAM_POLL_INTERVAL)
-
-    response = StreamingHttpResponse(event_stream(), content_type='text/event-stream')
-    response['Cache-Control'] = 'no-cache'
-    response['Content-Encoding'] = 'identity'
-    response['X-Accel-Buffering'] = 'no'
-    return response
+    current_offset = max(offset, 0)
+    try:
+        file_size = log_path.stat().st_size
+        if file_size < current_offset:
+            current_offset = max(file_size - clamped_tail_bytes, 0)
+            content, current_offset = _read_from_offset(log_path, current_offset)
+            return {
+                'content': content,
+                'offset': current_offset,
+                'size': file_size,
+                'status': 'reset',
+            }
+        if file_size > current_offset:
+            content, current_offset = _read_from_offset(log_path, current_offset)
+            return {
+                'content': content,
+                'offset': current_offset,
+                'size': file_size,
+                'status': 'ok',
+            }
+        return {
+            'content': '',
+            'offset': current_offset,
+            'size': file_size,
+            'status': 'ok',
+        }
+    except FileNotFoundError:
+        return {
+            'content': '',
+            'offset': 0,
+            'size': 0,
+            'status': 'deleted',
+        }
 
 
 @router.get('/diskusage', throttle=[AnonRateThrottle('30/m')])

--- a/back_end/saolei/common/tests.py
+++ b/back_end/saolei/common/tests.py
@@ -1,7 +1,9 @@
 from datetime import timedelta
 import json
+import os
 from pathlib import Path
 import tempfile
+from unittest.mock import patch
 
 from django.core.files import File
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -21,11 +23,89 @@ from tournament.models import GSCTournament
 from userprofile.models import UserProfile
 from utils.parser import MSVideoParser
 from videomanager.models import VideoModel
+from . import api as common_api
 
 
 FIXTURE_DIR = Path(__file__).resolve().parent / 'test_fixtures' / 'video_upload_ranking'
 EXPERT_PERSONAL_PLUCK = 0.16342814596696364
 CUSTOM_PLUCK_FIXTURE_PLUCK = 6.493148642054213
+
+
+class LogPollTests(TestCase):
+    def setUp(self):
+        self.log_dir_context = tempfile.TemporaryDirectory()
+        self.log_dir = Path(self.log_dir_context.name)
+        self.log_dir_patch = patch.object(common_api, 'LOG_DIR', self.log_dir)
+        self.log_dir_patch.start()
+
+    def tearDown(self):
+        self.log_dir_patch.stop()
+        self.log_dir_context.cleanup()
+
+    def write_log(self, filename: str, content: str):
+        path = self.log_dir / filename
+        path.write_bytes(content.encode())
+        return path
+
+    def test_poll_returns_content_from_offset(self):
+        content = 'first\nsecond\n'
+        offset = len('first\n'.encode())
+        self.write_log('app.log', content)
+
+        response = common_api.poll_log_tail(None, 'app.log', offset=offset)
+
+        self.assertEqual(response, {
+            'content': 'second\n',
+            'offset': len(content.encode()),
+            'size': len(content.encode()),
+            'status': 'ok',
+        })
+
+    def test_poll_returns_empty_content_when_offset_matches_file_size(self):
+        content = 'ready\n'
+        self.write_log('app.log', content)
+
+        response = common_api.poll_log_tail(None, 'app.log', offset=len(content.encode()))
+
+        self.assertEqual(response, {
+            'content': '',
+            'offset': len(content.encode()),
+            'size': len(content.encode()),
+            'status': 'ok',
+        })
+
+    def test_poll_returns_reset_and_tail_when_file_shrinks(self):
+        content = 'new-tail'
+        self.write_log('app.log', content)
+
+        response = common_api.poll_log_tail(None, 'app.log', offset=20, tail_bytes=4)
+
+        self.assertEqual(response, {
+            'content': 'tail',
+            'offset': len(content.encode()),
+            'size': len(content.encode()),
+            'status': 'reset',
+        })
+
+    def test_poll_returns_deleted_when_file_disappears(self):
+        response = common_api.poll_log_tail(None, 'app.log')
+
+        self.assertEqual(response, {
+            'content': '',
+            'offset': 0,
+            'size': 0,
+            'status': 'deleted',
+        })
+
+    def test_list_logs_uses_file_modified_time(self):
+        log_path = self.write_log('app.log', 'ready\n')
+        modified_at = 1710979200
+        os.utime(log_path, (modified_at - 3600, modified_at))
+
+        [response] = common_api.list_logs(None)
+
+        self.assertEqual(response['name'], 'app.log')
+        self.assertEqual(response['mtime'].timestamp(), modified_at)
 
 
 class VideoUploadRankingIntegrationTest(TestCase):

--- a/front_end/cypress/e2e/staff-logs.cy.ts
+++ b/front_end/cypress/e2e/staff-logs.cy.ts
@@ -43,17 +43,24 @@ describe('Staff logs', () => {
 
         cy.visit('/#/staff/logs');
         cy.wait('@listLogs');
+        cy.get('.log-tail-bytes input').clear();
+        cy.get('.log-tail-bytes input').type('1024');
+        cy.get('.log-tail-bytes input').blur();
 
-        cy.contains('.el-table__row', LOG_FILE).within(() => {
-            cy.contains('button', '查看').click();
-        });
+        cy.get('.log-file-select').click();
+        cy.contains('.el-select-dropdown__item', LOG_FILE).click();
         cy.wait('@logTail').its('response.statusCode').should('eq', 200);
 
         cy.contains('.log-toolbar', LOG_FILE);
         cy.get('.log-viewer').should('contain', 'cypress staff log start');
         cy.get('.log-viewer').should('contain', 'admin can read log tail');
         cy.get('.log-viewer').should('contain', 'cypress staff log end');
-        cy.contains('.log-toolbar', '实时更新中', { timeout: 10000 });
+        cy.contains('.log-toolbar', '已加载，轮询未启动');
+        cy.get('.log-poll-start').click();
+        cy.contains('.log-toolbar', '轮询更新中', { timeout: 10000 });
+        cy.get('.log-poll-ms input').clear();
+        cy.get('.log-poll-ms input').type('500');
+        cy.get('.log-poll-ms input').blur();
 
         writeLog(LOG_FILE, TAIL_UPDATE, true);
         cy.get('.log-viewer', { timeout: 15000 }).should('contain', TAIL_UPDATE.trim());

--- a/front_end/src/views/StaffView/Logs.vue
+++ b/front_end/src/views/StaffView/Logs.vue
@@ -1,22 +1,32 @@
 <template>
-    <ElButton @click="getLogDir">
-        获取日志目录
-    </ElButton>
-    <ElTable :data="fileStats">
-        <ElTableColumn prop="name" label="文件名" width="180" />
-        <ElTableColumn prop="size" label="大小" width="180" />
-        <ElTableColumn prop="mtime" label="修改时间" />
-        <ElTableColumn label="操作" width="180">
-            <template #default="scope">
-                <ElButton @click="viewLog(scope.row.name)">
-                    查看
-                </ElButton>
-                <ElButton @click="downloadLog(scope.row.name)">
-                    下载
-                </ElButton>
-            </template>
-        </ElTableColumn>
-    </ElTable>
+    <div class="log-selector">
+        <ElButton @click="getLogDir">
+            获取日志目录
+        </ElButton>
+        <ElSelect
+            v-model="selectedLog"
+            class="log-file-select"
+            filterable
+            placeholder="选择日志文件"
+            @change="viewLog"
+        >
+            <ElOption
+                v-for="file in fileStats"
+                :key="file.name"
+                :label="formatLogOption(file)"
+                :value="file.name"
+            >
+                <div class="log-option">
+                    <span class="log-option-name">{{ file.name }}</span>
+                    <span>{{ formatBytes(file.size) }}</span>
+                    <span>{{ formatLogTime(file.mtime) }}</span>
+                </div>
+            </ElOption>
+        </ElSelect>
+        <ElButton :disabled="selectedLog === ''" @click="downloadLog(selectedLog)">
+            下载
+        </ElButton>
+    </div>
     <div class="log-toolbar">
         <span v-if="selectedLog">
             {{ selectedLog }}
@@ -24,16 +34,51 @@
         <span>
             {{ streamStatus }}
         </span>
+        <ElButton
+            class="log-poll-start"
+            :disabled="selectedLog === '' || loadedLog !== selectedLog || isLogPolling"
+            @click="startLogPolling"
+        >
+            开始轮询
+        </ElButton>
+        <ElButton
+            class="log-poll-stop"
+            :disabled="!isLogPolling"
+            @click="stopLogPolling"
+        >
+            停止轮询
+        </ElButton>
+        <label class="log-poll-interval log-poll-ms">
+            轮询间隔
+            <ElInputNumber
+                v-model="logPollIntervalMs"
+                :min="200"
+                :max="60000"
+                controls-position="right"
+                @change="restartLogPolling"
+            />
+            ms
+        </label>
+        <label class="log-poll-interval log-tail-bytes">
+            尾部字节
+            <ElInputNumber
+                v-model="logTailBytes"
+                :min="1"
+                :max="MAX_TAIL_BYTES"
+                controls-position="right"
+            />
+        </label>
     </div>
-    <pre class="log-viewer">{{ logContent }}</pre>
+    <pre ref="logViewer" class="log-viewer">{{ logContent }}</pre>
 </template>
 
 <script lang="ts" setup>
-import { ElButton, ElTable, ElTableColumn } from 'element-plus';
-import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { ElButton, ElInputNumber, ElOption, ElSelect } from 'element-plus';
+import { nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue';
 
 import { httpErrorNotification } from '@/components/Notifications';
 import useCurrentInstance from '@/utils/common/useCurrentInstance';
+import { formatBytes } from '@/utils/strings';
 
 interface FileStat {
     name: string;
@@ -48,39 +93,74 @@ interface LogTailResponse {
     truncated: boolean;
 }
 
-interface LogStreamMessage {
+interface LogPollResponse {
     content: string;
     offset: number;
+    size: number;
+    status: 'ok' | 'reset' | 'deleted';
 }
 
 defineOptions({ name: 'StaffLogs' });
 
-const LOG_TAIL_BYTES = 64 * 1024;
-const MAX_VISIBLE_LOG_CHARS = 1024 * 1024;
+const DEFAULT_TAIL_BYTES = 65536;
+const MAX_TAIL_BYTES = 1048576;
+const MAX_VISIBLE_LOG_CHARS = 1048576;
 
 const { proxy } = useCurrentInstance();
 const fileStats = ref([] as FileStat[]);
 const logContent = ref('');
 const selectedLog = ref('');
 const streamStatus = ref('未连接');
-let logEventSource: EventSource | null = null;
+const logPollIntervalMs = ref(10000);
+const logTailBytes = ref(DEFAULT_TAIL_BYTES);
+const isLogPolling = ref(false);
+const loadedLog = ref('');
+const logViewer = useTemplateRef<HTMLElement>('logViewer');
+let logPollTimer: number | null = null;
+let logPollOffset = 0;
+let pollingLog = '';
 
-function closeLogStream() {
-    if (logEventSource === null) {
-        return;
-    }
-    logEventSource.close();
-    logEventSource = null;
+function closeLogPolling() {
+    if (logPollTimer === null) return;
+    window.clearInterval(logPollTimer);
+    logPollTimer = null;
+    isLogPolling.value = false;
 }
 
-function makeApiUrl(path: string, params: Record<string, string | number>) {
-    const rawBaseApi = import.meta.env.VITE_BASE_API as string | undefined;
-    const baseApi = rawBaseApi ?? window.location.origin;
-    const url = new URL(path, new URL(baseApi, window.location.origin));
-    for (const [key, value] of Object.entries(params)) {
-        url.searchParams.set(key, String(value));
+function stopLogPolling() {
+    closeLogPolling();
+    if (selectedLog.value !== '') streamStatus.value = '轮询已停止';
+}
+
+function normalizedLogPollIntervalMs() {
+    if (!Number.isFinite(logPollIntervalMs.value)) {
+        logPollIntervalMs.value = 1000;
     }
-    return url.toString();
+    logPollIntervalMs.value = Math.min(Math.max(logPollIntervalMs.value, 200), 60000);
+    return logPollIntervalMs.value;
+}
+
+function normalizedLogTailBytes() {
+    if (!Number.isFinite(logTailBytes.value)) {
+        logTailBytes.value = DEFAULT_TAIL_BYTES;
+    }
+    logTailBytes.value = Math.trunc(Math.min(Math.max(logTailBytes.value, 1), MAX_TAIL_BYTES));
+    return logTailBytes.value;
+}
+
+function scrollLogViewerToBottom() {
+    void nextTick(() => {
+        if (logViewer.value === null) return;
+        logViewer.value.scrollTop = logViewer.value.scrollHeight;
+    });
+}
+
+function formatLogTime(mtime: string) {
+    return new Date(mtime).toLocaleString();
+}
+
+function formatLogOption(file: FileStat) {
+    return `${file.name} | ${formatBytes(file.size)} | ${formatLogTime(file.mtime)}`;
 }
 
 function appendLogContent(content: string) {
@@ -88,33 +168,59 @@ function appendLogContent(content: string) {
     if (logContent.value.length > MAX_VISIBLE_LOG_CHARS) {
         logContent.value = logContent.value.slice(-MAX_VISIBLE_LOG_CHARS);
     }
+    scrollLogViewerToBottom();
 }
 
-function openLogStream(log: string, offset: number) {
-    closeLogStream();
-    streamStatus.value = '正在连接实时更新';
-    logEventSource = new EventSource(makeApiUrl('/api/common/staff/logstream', {
-        filename: log,
-        offset,
-        tail_bytes: LOG_TAIL_BYTES,
-    }), { withCredentials: true });
-    logEventSource.onopen = () => {
-        streamStatus.value = '实时更新中';
-    };
-    logEventSource.onmessage = (event) => {
-        const data = JSON.parse(event.data) as LogStreamMessage;
-        appendLogContent(data.content);
-    };
-    logEventSource.addEventListener('reset', () => {
-        logContent.value = '[日志文件已被截断或轮转，正在从新文件继续读取]\n';
-    });
-    logEventSource.addEventListener('deleted', () => {
+function applyLogPoll(data: LogPollResponse) {
+    if (data.status === 'deleted') {
         streamStatus.value = '日志文件已删除';
-        closeLogStream();
+        closeLogPolling();
+        return;
+    }
+    if (data.status === 'reset') {
+        logContent.value = '[日志文件已被截断或轮转，正在从新文件继续读取]\n';
+    }
+    if (data.content !== '') {
+        appendLogContent(data.content);
+    }
+    logPollOffset = data.offset;
+}
+
+function pollLogTail() {
+    if (pollingLog === '' || !isLogPolling.value) return;
+    proxy.$axios.get('/api/common/staff/logpoll', {
+        params: {
+            filename: pollingLog,
+            offset: logPollOffset,
+            tail_bytes: normalizedLogTailBytes(),
+        },
+    }).then((response) => {
+        applyLogPoll(response.data as LogPollResponse);
+    }).catch((error: unknown) => {
+        streamStatus.value = '轮询更新失败';
+        closeLogPolling();
+        httpErrorNotification(error);
     });
-    logEventSource.onerror = () => {
-        streamStatus.value = '实时连接中断，浏览器将自动重连';
-    };
+}
+
+function startLogPolling() {
+    if (selectedLog.value === '') return;
+    closeLogPolling();
+    pollingLog = selectedLog.value;
+    streamStatus.value = '轮询更新中';
+    logPollTimer = window.setInterval(pollLogTail, normalizedLogPollIntervalMs());
+    isLogPolling.value = true;
+}
+
+function restartLogPolling() {
+    if (!isLogPolling.value || pollingLog === '') {
+        normalizedLogPollIntervalMs();
+        return;
+    }
+    closeLogPolling();
+    streamStatus.value = '轮询更新中';
+    logPollTimer = window.setInterval(pollLogTail, normalizedLogPollIntervalMs());
+    isLogPolling.value = true;
 }
 
 function getLogDir() {
@@ -126,16 +232,22 @@ function getLogDir() {
 }
 
 function viewLog(log: string) {
-    closeLogStream();
-    selectedLog.value = log;
+    closeLogPolling();
     streamStatus.value = '正在加载日志尾部';
-    proxy.$axios.get('/api/common/staff/logtail', { params: { filename: log, tail_bytes: LOG_TAIL_BYTES } }).then(
+    pollingLog = '';
+    loadedLog.value = '';
+    const tailBytes = normalizedLogTailBytes();
+    proxy.$axios.get('/api/common/staff/logtail', { params: { filename: log, tail_bytes: tailBytes } }).then(
         function (response) {
             const data = response.data as LogTailResponse;
             logContent.value = data.truncated
-                ? `[仅显示最后 ${LOG_TAIL_BYTES} 字节]\n${data.content}`
+                ? `[仅显示最后 ${tailBytes} 字节]\n${data.content}`
                 : data.content;
-            openLogStream(log, data.offset);
+            scrollLogViewerToBottom();
+            pollingLog = log;
+            logPollOffset = data.offset;
+            loadedLog.value = log;
+            streamStatus.value = '已加载，轮询未启动';
         },
     ).catch((error: unknown) => {
         streamStatus.value = '加载失败';
@@ -158,14 +270,45 @@ function downloadLog(log: string) {
 }
 
 onMounted(getLogDir);
-onBeforeUnmount(closeLogStream);
+onBeforeUnmount(closeLogPolling);
 </script>
 
 <style scoped>
+.log-selector {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.log-file-select {
+    width: min(48rem, 70vw);
+}
+
+.log-option {
+    display: grid;
+    grid-template-columns: minmax(10rem, 1fr) 6rem 12rem;
+    align-items: center;
+    gap: 1rem;
+}
+
+.log-option-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .log-toolbar {
     display: flex;
+    align-items: center;
+    flex-wrap: wrap;
     gap: 1rem;
     margin: 1rem 0 0.5rem;
+}
+
+.log-poll-interval {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
 }
 
 .log-viewer {


### PR DESCRIPTION
Replace Server-Sent Events streaming with HTTP polling for log tailing, providing simpler state management and better client control.

Key changes:
- Refactor `/staff/logstream` endpoint to `/staff/logpoll` returning JSON responses
- Add `LogPollOut` schema with status field (ok/reset/deleted)
- Fix file timestamp bug: use `st_mtime` instead of `st_ctime` in `list_logs`
- Improve path validation in poll endpoint
- Update frontend UI from table to dropdown selector with polling controls
- Add controls for poll interval (200-60000ms) and tail bytes configuration
- Add comprehensive `LogPollTests` covering edge cases (offset, truncation, deletion)
- Update e2e tests for new UI and status messages