### PR TITLE
Normalize optional stats to NaN and use direct props

### DIFF
--- a/front_end/src/components/VideoList/ColumnStat.vue
+++ b/front_end/src/components/VideoList/ColumnStat.vue
@@ -1,5 +1,5 @@
 <template>
-    <PrColumn :header="t(`common.prop.${ stat}`)" :sortable="sortable" :sort-field="(data) => data.getStat(stat)">
+    <PrColumn :header="t(`common.prop.${ stat}`)" :sortable="sortable" :sort-field="stat">
         <template #body="{data}: {data: VideoAbstract}">
             <span class="text">{{ data.displayStat(stat) }}</span>
         </template>

--- a/front_end/src/components/visualization/BBBvSummary/Cell.vue
+++ b/front_end/src/components/visualization/BBBvSummary/Cell.vue
@@ -59,7 +59,7 @@ watch(props, refresh, { immediate: true });
 
 const color = computed(() => {
     if (bestIndex.value === -1) return 'rgba(0,0,0,0)';
-    return props.colorTheme.getColor(props.videos[bestIndex.value].getStat(props.displayBy));
+    return props.colorTheme.getColor(props.videos[bestIndex.value][props.displayBy]);
 });
 
 const fontColor = computed(() => {

--- a/front_end/src/components/visualization/BBBvSummary/utils.ts
+++ b/front_end/src/components/visualization/BBBvSummary/utils.ts
@@ -16,8 +16,8 @@ export function getBest(videos: VideoAbstract[], option: SortOption): {
     for (let i = 0; i < videos.length; i++) {
         const video = videos[i];
         if (!option.softwareFilter.includes(video.software)) break;
-        const thisValue = video.getStat(option.sortBy);
-        if (thisValue === undefined) {
+        const thisValue = video[option.sortBy];
+        if (isNaN(thisValue)) {
             bestValue = NaN;
             bestIndex = -1;
             break;

--- a/front_end/src/components/visualization/GSCPersonalSummary/Cell.vue
+++ b/front_end/src/components/visualization/GSCPersonalSummary/Cell.vue
@@ -45,7 +45,7 @@ const props = defineProps({
 
 const color = computed(() => {
     if (!props.video) return props.colorTheme.getColor(defaultVideos[props.level][props.displayBy]);
-    return props.colorTheme.getColor(props.video.getStat(props.displayBy));
+    return props.colorTheme.getColor(props.video[props.displayBy]);
 });
 
 const fontColor = computed(() => {

--- a/front_end/src/components/visualization/GSCPersonalSummary/SortedColumn.vue
+++ b/front_end/src/components/visualization/GSCPersonalSummary/SortedColumn.vue
@@ -64,11 +64,10 @@ const colorScheme = computed(() => {
     }
 });
 
-const _videos = computed(() => props.videos.filter((video) => video.getStat(props.sortBy) !== undefined));
+const _videos = computed(() => props.videos.filter((video) => !isNaN(video[props.sortBy])));
 
 const sortedVideos = computed(() => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const sorted = Array.from(_videos.value).sort((v1, v2) => v1.getStat(props.sortBy)! - v2.getStat(props.sortBy)!);
+    const sorted = Array.from(_videos.value).sort((v1, v2) => v1[props.sortBy] - v2[props.sortBy]);
     if (props.sortBy === 'time') {
         return sorted.slice(0, props.count);
     } else {
@@ -77,8 +76,7 @@ const sortedVideos = computed(() => {
 });
 
 const sumStat = computed(() => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return sum(sortedVideos.value, (video) => video.getStat(props.sortBy)!) + (props.count - sortedVideos.value.length) * defaultVideos[props.level][props.sortBy];
+    return sum(sortedVideos.value, (video) => video[props.sortBy]) + (props.count - sortedVideos.value.length) * defaultVideos[props.level][props.sortBy];
 });
 
 const avgStat = computed(() => {

--- a/front_end/src/components/visualization/VideoScatter/README.md
+++ b/front_end/src/components/visualization/VideoScatter/README.md
@@ -52,7 +52,7 @@ App.vue
 
 - `level`：直接使用 `colorTheme.value.level[video.level]`。
 - `time`：按视频所属的 `MS_Level` 获取对应的分段时间配色方案。
-- 其他统计字段：通过 `getPiecewiseColorSchemeName(colorBy)` 获取分段配色方案，再用 `video.getStat(colorBy)` 映射颜色。
+- 其他统计字段：通过 `getPiecewiseColorSchemeName(colorBy)` 获取分段配色方案，再用 `video[colorBy]` 映射颜色。
 
 `scatterData` 会逐个处理 `rawData`：
 

--- a/front_end/src/components/visualization/VideoScatter/store.ts
+++ b/front_end/src/components/visualization/VideoScatter/store.ts
@@ -49,7 +49,7 @@ export const VideoScatterStore = defineStore('video-scatter-store', {
             } else {
                 const name = getPiecewiseColorSchemeName(colorBy);
                 const scheme = new PiecewiseColorScheme(colorTheme.value[name].colors, colorTheme.value[name].thresholds);
-                return (video: VideoAbstract) => scheme.getColor(video.getStat(colorBy));
+                return (video: VideoAbstract) => scheme.getColor(video[colorBy]);
             }
         },
         scatterData() {

--- a/front_end/src/components/visualization/VideoScatter/utils.ts
+++ b/front_end/src/components/visualization/VideoScatter/utils.ts
@@ -4,11 +4,11 @@ import type { getStat_stat, VideoAbstract } from '@/utils/videoabstract';
 
 export function videoToPlotPoint(video: VideoAbstract, statX: getStat_stat, statY: getStat_stat): PlotPoint<VideoAbstract> | undefined {
     const point = {
-        x: video.getStat(statX),
-        y: video.getStat(statY),
+        x: video[statX],
+        y: video[statY],
         data: video,
     };
 
-    if (!Number.isFinite(point.x) || !Number.isFinite(point.y)) return undefined;
-    return point as PlotPoint<VideoAbstract>;
+    if (isNaN(point.x) || isNaN(point.y)) return undefined;
+    return point;
 }

--- a/front_end/src/utils/colors.test.ts
+++ b/front_end/src/utils/colors.test.ts
@@ -38,5 +38,11 @@ describe('PiecewiseColorScheme', () => {
             expect(scheme.getColor(15)).toBe('normal');
             expect(scheme.getColor(5)).toBe('slow');
         });
+
+        it('Returns transparent color for NaN', () => {
+            const scheme = new PiecewiseColorScheme(['low', 'high'], [10]);
+
+            expect(scheme.getColor(NaN)).toBe('rgba(0,0,0,0)');
+        });
     });
 });

--- a/front_end/src/utils/colors.ts
+++ b/front_end/src/utils/colors.ts
@@ -60,7 +60,7 @@ export class PiecewiseColorScheme {
      * @returns 返回对应的颜色字符串。
      */
     public getColor(value?: number): string {
-        if (value === undefined) return 'rgba(0,0,0,0)';
+        if (value === undefined || isNaN(value)) return 'rgba(0,0,0,0)';
         if (this.colors.length === 0) return 'rgba(0,0,0,0)';
         const index = ArrayUtils.getInsertIndex(this.thresholds, value, this.ascending);
         return this.colors[index];

--- a/front_end/src/utils/videoabstract.test.ts
+++ b/front_end/src/utils/videoabstract.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { VideoAbstract } from './videoabstract';
+import type { VideoAbstractData } from './videoabstract';
+
+function makeVideo(overrides: Partial<VideoAbstractData> = {}) {
+    return new VideoAbstract({
+        level: 'e',
+        mode: '00',
+        timems: 10000,
+        bv: 100,
+        software: 'e',
+        ...overrides,
+    });
+}
+
+describe('VideoAbstract', () => {
+    it('Normalizes missing optional stats to NaN', () => {
+        const video = makeVideo({
+            cl: null,
+            ce: undefined,
+            path: null,
+            pluck: undefined,
+        });
+
+        expect(isNaN(video.cl)).toBe(true);
+        expect(isNaN(video.ce)).toBe(true);
+        expect(isNaN(video.path)).toBe(true);
+        expect(isNaN(video.pluck)).toBe(true);
+        expect(isNaN(video.ioe)).toBe(true);
+        expect(isNaN(video.corr)).toBe(true);
+        expect(video.displayStat('ioe')).toBe('NaN');
+        expect(video.displayStat('path')).toBe('NaN');
+    });
+
+    it('Computes optional stats directly when source values are present', () => {
+        const video = makeVideo({
+            cl: 200,
+            ce: 50,
+            path: 32,
+            pluck: 1.25,
+        });
+
+        expect(video.ioe).toBe(0.5);
+        expect(video.thrp).toBe(2);
+        expect(video.corr).toBe(0.25);
+        expect(video.cls).toBe(20);
+        expect(video.ces).toBe(5);
+        expect(video.npath).toBe(2);
+        expect(video.mov).toBe(0.2);
+        expect(video.iome).toBe(50);
+        expect(video.displayStat('iome')).toBe('50.000');
+    });
+});

--- a/front_end/src/utils/videoabstract.ts
+++ b/front_end/src/utils/videoabstract.ts
@@ -8,27 +8,6 @@ import { formatBytes } from './strings';
 type VideoLevel = MS_Level | CustomLevel;
 export type StandardVideoAbstract = VideoAbstract & { level: MS_Level };
 
-function undefinedOrToString(value: { toString: () => string } | undefined): string | undefined {
-    return value === undefined ? undefined : value.toString();
-}
-
-function undefinedOrToFixed(value: number | undefined, digits: number): string | undefined {
-    return value === undefined ? undefined : value.toFixed(digits);
-}
-
-function undefinedDivideNumber(a: number | undefined, b: number): number | undefined {
-    if (a === undefined) return undefined;
-    return a / b;
-}
-function numberDivideUndefined(a: number, b: number | undefined): number | undefined {
-    if (b === undefined) return undefined;
-    return a / b;
-}
-function undefinedDivideUndefined(a: number | undefined, b: number | undefined): number | undefined {
-    if (a === undefined || b === undefined) return undefined;
-    return a / b;
-}
-
 export interface VideoAbstractInfo {
     id: number;
     upload_time: string | Date;
@@ -93,10 +72,10 @@ export class VideoAbstract {
     public bv: number;
     public state: MS_State = MS_State.Plain;
     public software: MS_Software;
-    public cl?: number;
-    public ce?: number;
-    public path?: number;
-    public pluck?: number;
+    public cl = NaN;
+    public ce = NaN;
+    public path = NaN;
+    public pluck = NaN;
     public player_id?: number;
     public file_size = 0;
     public ongoing_tournament?: boolean;
@@ -116,10 +95,10 @@ export class VideoAbstract {
         if (info.state !== undefined) this.state = info.state as MS_State;
         this.software = info.software as MS_Software;
 
-        this.cl = info.cl ?? undefined;
-        this.ce = info.ce ?? undefined;
-        this.path = info.path ?? undefined;
-        this.pluck = info.pluck ?? undefined;
+        this.cl = info.cl ?? NaN;
+        this.ce = info.ce ?? NaN;
+        this.path = info.path ?? NaN;
+        this.pluck = info.pluck ?? NaN;
         this.player_id = info.player_id ?? info.player;
 
         this.file_size = info.file_size ?? this.file_size;
@@ -164,43 +143,39 @@ export class VideoAbstract {
         return STNB_const.value[this.level] / this.qg;
     }
 
-    public get ioe(): number | undefined {
-        return numberDivideUndefined(this.bv, this.cl);
+    public get ioe(): number {
+        return this.bv / this.cl;
     }
 
-    public get thrp(): number | undefined {
-        return numberDivideUndefined(this.bv, this.ce);
+    public get thrp(): number {
+        return this.bv / this.ce;
     }
 
-    public get corr(): number | undefined {
-        return undefinedDivideUndefined(this.ce, this.cl);
+    public get corr(): number {
+        return this.ce / this.cl;
     }
 
-    public get cls(): number | undefined {
-        return undefinedDivideNumber(this.cl, this.time);
+    public get cls(): number {
+        return this.cl / this.time;
     }
 
-    public get ces(): number | undefined {
-        return undefinedDivideNumber(this.ce, this.time);
+    public get ces(): number {
+        return this.ce / this.time;
     }
 
-    public get npath(): number | undefined {
-        return undefinedDivideNumber(this.path, 16);
+    public get npath(): number {
+        return this.path / 16;
     }
 
-    public get mov(): number | undefined {
-        return undefinedDivideNumber(this.npath, this.time);
+    public get mov(): number {
+        return this.npath / this.time;
     }
 
-    public get iome(): number | undefined {
-        return numberDivideUndefined(this.bv, this.npath);
+    public get iome(): number {
+        return this.bv / this.npath;
     }
 
-    public getStat(stat: getStat_stat): number | undefined {
-        return this[stat];
-    }
-
-    public displayStat(stat: getStat_stat): string | undefined {
+    public displayStat(stat: getStat_stat): string {
         switch (stat) {
             case 'timems':
             case 'time': return this.time.toFixed(3);
@@ -209,21 +184,20 @@ export class VideoAbstract {
             case 'qg': return this.qg.toFixed(3);
             case 'rqp': return this.rqp.toFixed(3);
             case 'stnb': return this.stnb.toFixed(1);
-            case 'ce': return undefinedOrToString(this.ce);
-            case 'ces': return undefinedOrToFixed(this.ces, 3);
-            case 'cl': return undefinedOrToString(this.cl);
-            case 'cls': return undefinedOrToFixed(this.cls, 3);
-            case 'ioe': return undefinedOrToFixed(this.ioe, 3);
-            case 'thrp': return undefinedOrToFixed(this.thrp, 3);
-            case 'corr': return undefinedOrToFixed(this.corr, 3);
-            case 'path': return undefinedOrToFixed(this.path, 0);
-            case 'pluck': return undefinedOrToFixed(this.pluck, 3);
-            case 'npath': return undefinedOrToFixed(this.npath, 1);
-            case 'mov': return undefinedOrToFixed(this.mov, 3);
-            case 'iome': return undefinedOrToFixed(this.iome, 3);
+            case 'ce': return this.ce.toString();
+            case 'ces': return this.ces.toFixed(3);
+            case 'cl': return this.cl.toString();
+            case 'cls': return this.cls.toFixed(3);
+            case 'ioe': return this.ioe.toFixed(3);
+            case 'thrp': return this.thrp.toFixed(3);
+            case 'corr': return this.corr.toFixed(3);
+            case 'path': return this.path.toFixed(0);
+            case 'pluck': return this.pluck.toFixed(3);
+            case 'npath': return this.npath.toFixed(1);
+            case 'mov': return this.mov.toFixed(3);
+            case 'iome': return this.iome.toFixed(3);
             case 'file_size': return formatBytes(this.file_size);
         }
-        return undefined;
     }
 }
 


### PR DESCRIPTION
- Normalize optional numeric fields in VideoAbstract to NaN and remove undefined-returning helpers.
- VideoAbstract getters now always return numbers and displayStat always returns a string; getStat was removed in favor of direct property access (video[stat]).
- Updated components, stores, utils and README to use direct property access and isNaN checks (sorting, filtering, color mapping, scatter points).
- PiecewiseColorScheme now returns transparent for NaN.
- Added tests for videoabstract and colors to cover NaN behavior.

This simplifies numeric handling and removes scattered undefined checks; note the getStat API change may be breaking for callers.