### PR TITLE
添加规则`@typescript-eslint/no-unsafe-argument`

### DIFF
--- a/back_end/saolei/common/tests.py
+++ b/back_end/saolei/common/tests.py
@@ -164,13 +164,23 @@ class VideoUploadRankingIntegrationTest(TestCase):
         return json.loads(response.content)
 
     def get_records_by_request(self):
-        response = self.client.get('/msuser/records/', {'id': self.user.id})
+        response = self.client.get('/api/msuser/records', {'id': self.user.id})
         self.assertEqual(response.status_code, 200, response.content)
         return response.json()
 
     def get_record_group_by_request(self, mode: str):
         records = self.get_records_by_request()
-        return json.loads(records[f'{mode}_record'])
+        grouped_records = {}
+        for stat in RankingGameStats:
+            grouped_records[stat] = [
+                records[f'{level}_{stat}_{mode}']
+                for level in GameLevels
+            ]
+            grouped_records[f'{stat}_id'] = [
+                records[f'{level}_{stat}_id_{mode}']
+                for level in GameLevels
+            ]
+        return grouped_records
 
     def get_pluck_rank_by_request(self, level: str):
         response = self.client.get(

--- a/back_end/saolei/common/tests.py
+++ b/back_end/saolei/common/tests.py
@@ -164,7 +164,7 @@ class VideoUploadRankingIntegrationTest(TestCase):
         return json.loads(response.content)
 
     def get_records_by_request(self):
-        response = self.client.get('/api/msuser/records', {'id': self.user.id})
+        response = self.client.get('/api/msuser/records', {'user_id': self.user.id})
         self.assertEqual(response.status_code, 200, response.content)
         return response.json()
 

--- a/back_end/saolei/dangerzone/api.py
+++ b/back_end/saolei/dangerzone/api.py
@@ -4,6 +4,8 @@ from ninja import NinjaAPI, Schema
 from ninja.errors import HttpError
 
 from common.api import LOG_DIR
+from identifier.models import Identifier
+from identifier.services import bind_identifier, set_safe, unbind_identifier
 from msuser.models import UserMS
 from userprofile.models import UserProfile
 from videomanager.models import ExpandVideoModel, VideoModel
@@ -36,6 +38,17 @@ class CreateVideoSchema(Schema):
     pluck: float | None = None
 
 
+class IdentifierSchema(Schema):
+    identifier: str
+    safe: bool = True
+
+
+class UserIdentifierSchema(Schema):
+    user_id: int
+    identifier: str
+    safe: bool = True
+
+
 class WriteLogSchema(Schema):
     filename: str
     content: str
@@ -54,13 +67,21 @@ class RegisterSchema(Schema):
     email: str
     password: str
     id: int
+    realname: str = '匿名'
 
 
 @api.post('/register')
 @local_only
 def register(request, data: RegisterSchema):
     userms = UserMS.objects.create()
-    UserProfile.objects.create_user(username=data.username, password=data.password, id=data.id, email=data.email, userms=userms)
+    UserProfile.objects.create_user(
+        username=data.username,
+        password=data.password,
+        id=data.id,
+        email=data.email,
+        realname=data.realname,
+        userms=userms,
+    )
 
 
 @api.post('/create_video')
@@ -89,6 +110,91 @@ def create_video(request, data: CreateVideoSchema):
         pluck=data.pluck,
     )
     return {'id': video.id}
+
+
+@api.post('/create_identifier')
+@local_only
+def create_identifier(request, data: IdentifierSchema):
+    identifier, _ = Identifier.objects.get_or_create(
+        identifier=data.identifier,
+        defaults={'safe': data.safe},
+    )
+    try:
+        set_safe(identifier, data.safe)
+    except ValueError as error:
+        raise HttpError(400, str(error)) from error
+
+    return {
+        'identifier': identifier.identifier,
+        'safe': identifier.safe,
+        'userms_id': identifier.userms_id,
+    }
+
+
+@api.post('/bind_identifier')
+@local_only
+def bind_identifier_to_user(request, data: UserIdentifierSchema):
+    user = UserProfile.objects.select_related('userms').get(id=data.user_id)
+    identifier, _ = Identifier.objects.get_or_create(
+        identifier=data.identifier,
+        defaults={'safe': data.safe},
+    )
+    if data.safe and not identifier.safe:
+        set_safe(identifier, True)
+
+    try:
+        changed_count = bind_identifier(identifier, user.userms)
+    except ValueError as error:
+        raise HttpError(400, str(error)) from error
+
+    return {
+        'identifier': identifier.identifier,
+        'safe': identifier.safe,
+        'user_id': user.id,
+        'changed_count': changed_count,
+    }
+
+
+@api.post('/unbind_identifier')
+@local_only
+def unbind_identifier_from_user(request, data: UserIdentifierSchema):
+    user = UserProfile.objects.select_related('userms').get(id=data.user_id)
+    try:
+        identifier = Identifier.objects.get(identifier=data.identifier)
+        changed_count = unbind_identifier(identifier, user.userms)
+    except Identifier.DoesNotExist as error:
+        raise HttpError(404, 'Identifier not found') from error
+    except ValueError as error:
+        raise HttpError(400, str(error)) from error
+
+    return {
+        'identifier': identifier.identifier,
+        'user_id': user.id,
+        'changed_count': changed_count,
+    }
+
+
+@api.post('/delete_identifier')
+@local_only
+def delete_identifier(request, data: IdentifierSchema):
+    try:
+        identifier = Identifier.objects.get(identifier=data.identifier)
+    except Identifier.DoesNotExist:
+        return {
+            'identifier': data.identifier,
+            'deleted': False,
+            'changed_count': 0,
+        }
+
+    changed_count = 0
+    if identifier.userms_id is not None:
+        changed_count = unbind_identifier(identifier)
+    identifier.delete()
+    return {
+        'identifier': data.identifier,
+        'deleted': True,
+        'changed_count': changed_count,
+    }
 
 
 @api.post('/setstaff')

--- a/back_end/saolei/msuser/api.py
+++ b/back_end/saolei/msuser/api.py
@@ -41,17 +41,17 @@ UserMSRecordsAbstractOut = create_schema(
 
 @router.get('/records', response=UserMSRecordsOut)
 @decorate_view(ratelimit(key='ip', rate='15/m'))
-def get_records(request, id: int):
+def get_records(request, user_id: int):
     """
     - ratelimit(key='ip', rate='15/m')
     """
-    return get_object_or_404(UserMS, parent__id=id)
+    return get_object_or_404(UserMS, parent__id=user_id)
 
 
 @router.get('/records_abstract', response=UserMSRecordsAbstractOut)
 @decorate_view(ratelimit(key='ip', rate='5/s'))
-def get_records_abstract(request, id: int):
+def get_records_abstract(request, user_id: int):
     """
     - ratelimit(key='ip', rate='5/s')
     """
-    return get_object_or_404(UserMS, parent__id=id)
+    return get_object_or_404(UserMS, parent__id=user_id)

--- a/back_end/saolei/msuser/api.py
+++ b/back_end/saolei/msuser/api.py
@@ -9,6 +9,8 @@ from .models import UserMS
 
 router = Router()
 
+RECORD_ABSTRACT_STATS = ('timems', 'bvs')
+
 UserMSRecordsOut = create_schema(
     UserMS,
     fields=[
@@ -23,11 +25,33 @@ UserMSRecordsOut = create_schema(
     ],
 )
 
+UserMSRecordsAbstractOut = create_schema(
+    UserMS,
+    fields=[
+        field
+        for stat in RECORD_ABSTRACT_STATS
+        for level in GameLevels
+        for field in (
+            f'{level}_{stat}_std',
+            f'{level}_{stat}_id_std',
+        )
+    ],
+)
+
 
 @router.get('/records', response=UserMSRecordsOut)
 @decorate_view(ratelimit(key='ip', rate='15/m'))
 def get_records(request, id: int):
     """
     - ratelimit(key='ip', rate='15/m')
+    """
+    return get_object_or_404(UserMS, parent__id=id)
+
+
+@router.get('/records_abstract', response=UserMSRecordsAbstractOut)
+@decorate_view(ratelimit(key='ip', rate='5/s'))
+def get_records_abstract(request, id: int):
+    """
+    - ratelimit(key='ip', rate='5/s')
     """
     return get_object_or_404(UserMS, parent__id=id)

--- a/back_end/saolei/msuser/api.py
+++ b/back_end/saolei/msuser/api.py
@@ -1,0 +1,33 @@
+from django.shortcuts import get_object_or_404
+from django_ratelimit.decorators import ratelimit
+from ninja import Router
+from ninja.decorators import decorate_view
+from ninja.orm import create_schema
+
+from config.global_settings import GameLevels, GameModes, RankingGameStats
+from .models import UserMS
+
+router = Router()
+
+UserMSRecordsOut = create_schema(
+    UserMS,
+    fields=[
+        field
+        for mode in GameModes
+        for stat in RankingGameStats
+        for level in GameLevels
+        for field in (
+            f'{level}_{stat}_{mode}',
+            f'{level}_{stat}_id_{mode}',
+        )
+    ],
+)
+
+
+@router.get('/records', response=UserMSRecordsOut)
+@decorate_view(ratelimit(key='ip', rate='15/m'))
+def get_records(request, id: int):
+    """
+    - ratelimit(key='ip', rate='15/m')
+    """
+    return get_object_or_404(UserMS, parent__id=id)

--- a/back_end/saolei/msuser/tests.py
+++ b/back_end/saolei/msuser/tests.py
@@ -30,6 +30,48 @@ class UserMSRecordApiTests(TestCase):
         self.assertNotIn('id', data)
         self.assertEqual(data['b_timems_std'], 1234)
 
+    def test_records_abstract_response_serializes_std_time_and_bvs_fields(self):
+        userms = UserMS.objects.create(
+            b_timems_std=12345,
+            i_timems_std=45678,
+            e_timems_std=78901,
+            b_timems_id_std=101,
+            i_timems_id_std=102,
+            e_timems_id_std=103,
+            b_bvs_std=1.2345,
+            i_bvs_std=2.3456,
+            e_bvs_std=3.4567,
+            b_bvs_id_std=201,
+            i_bvs_id_std=202,
+            e_bvs_id_std=203,
+        )
+        user = UserProfile.objects.create_user(
+            username='api_abstract_player',
+            email='api_abstract_player@example.com',
+            password='password',
+            userms=userms,
+        )
+
+        with self.assertNumQueries(1):
+            response = self.client.get('/api/msuser/records_abstract', {'id': user.id})
+
+        self.assertEqual(response.status_code, 200, response.content)
+        data = response.json()
+        self.assertNotIn('record_abstract', data)
+        self.assertNotIn('b_stnb_std', data)
+        self.assertEqual(data['b_timems_std'], 12345)
+        self.assertEqual(data['i_timems_std'], 45678)
+        self.assertEqual(data['e_timems_std'], 78901)
+        self.assertEqual(data['b_timems_id_std'], 101)
+        self.assertEqual(data['i_timems_id_std'], 102)
+        self.assertEqual(data['e_timems_id_std'], 103)
+        self.assertAlmostEqual(data['b_bvs_std'], 1.2345)
+        self.assertAlmostEqual(data['i_bvs_std'], 2.3456)
+        self.assertAlmostEqual(data['e_bvs_std'], 3.4567)
+        self.assertEqual(data['b_bvs_id_std'], 201)
+        self.assertEqual(data['i_bvs_id_std'], 202)
+        self.assertEqual(data['e_bvs_id_std'], 203)
+
 
 class PersonalRecordSignalTests(TestCase):
     def setUp(self):

--- a/back_end/saolei/msuser/tests.py
+++ b/back_end/saolei/msuser/tests.py
@@ -23,7 +23,7 @@ class UserMSRecordApiTests(TestCase):
         )
 
         with self.assertNumQueries(1):
-            response = self.client.get('/api/msuser/records', {'id': user.id})
+            response = self.client.get('/api/msuser/records', {'user_id': user.id})
 
         self.assertEqual(response.status_code, 200, response.content)
         data = response.json()
@@ -53,7 +53,7 @@ class UserMSRecordApiTests(TestCase):
         )
 
         with self.assertNumQueries(1):
-            response = self.client.get('/api/msuser/records_abstract', {'id': user.id})
+            response = self.client.get('/api/msuser/records_abstract', {'user_id': user.id})
 
         self.assertEqual(response.status_code, 200, response.content)
         data = response.json()

--- a/back_end/saolei/msuser/tests.py
+++ b/back_end/saolei/msuser/tests.py
@@ -12,6 +12,25 @@ from .signals import get_stats_update_set
 from .utils import RankingField, RankingValue
 
 
+class UserMSRecordApiTests(TestCase):
+    def test_records_response_serializes_records_without_parent_lookup(self):
+        userms = UserMS.objects.create(b_timems_std=1234)
+        user = UserProfile.objects.create_user(
+            username='api_player',
+            email='api_player@example.com',
+            password='password',
+            userms=userms,
+        )
+
+        with self.assertNumQueries(1):
+            response = self.client.get('/api/msuser/records', {'id': user.id})
+
+        self.assertEqual(response.status_code, 200, response.content)
+        data = response.json()
+        self.assertNotIn('id', data)
+        self.assertEqual(data['b_timems_std'], 1234)
+
+
 class PersonalRecordSignalTests(TestCase):
     def setUp(self):
         self.cache = get_redis_connection('saolei_website')

--- a/back_end/saolei/msuser/urls.py
+++ b/back_end/saolei/msuser/urls.py
@@ -3,6 +3,5 @@ from django.urls import path
 from . import views
 app_name = 'msuser'
 urlpatterns = [
-    path('info_abstract/', views.get_info_abstract, name='info_abstract'),
     path('player_rank/', views.player_rank, name='player_rank'),
 ]

--- a/back_end/saolei/msuser/urls.py
+++ b/back_end/saolei/msuser/urls.py
@@ -4,6 +4,5 @@ from . import views
 app_name = 'msuser'
 urlpatterns = [
     path('info_abstract/', views.get_info_abstract, name='info_abstract'),
-    path('records/', views.get_records, name='records'),
     path('player_rank/', views.player_rank, name='player_rank'),
 ]

--- a/back_end/saolei/msuser/views.py
+++ b/back_end/saolei/msuser/views.py
@@ -7,7 +7,7 @@ from django.views.decorators.http import require_GET
 from django_ratelimit.decorators import ratelimit
 from django_redis import get_redis_connection
 
-from config.global_settings import GameLevels, GameModes, RankingGameStats
+from config.global_settings import GameLevels
 from msuser.models import UserMS
 from msuser.utils import RankingField
 from userprofile.models import UserProfile
@@ -33,26 +33,6 @@ def get_records_level(ms_user: UserMS, stat: str, mode: str):
 
 def get_record_ids_level(ms_user: UserMS, stat: str, mode: str):
     return [getattr(ms_user, RankingField(level, stat, mode).id_name) for level in GameLevels]
-
-
-# 获取我的地盘里的姓名、全部纪录
-@ratelimit(key='ip', rate='15/m')
-@require_GET
-def get_records(request):
-    if not (user_id := request.GET.get('id')):
-        return HttpResponseBadRequest()
-    if not (user := UserProfile.objects.filter(id=user_id).first()):
-        return HttpResponseNotFound()
-    ms_user = user.userms
-
-    response = {'id': user_id}
-    for mode in GameModes:
-        value = {}
-        for stat in RankingGameStats:
-            value[stat] = get_records_level(ms_user, stat, mode)
-            value[f'{stat}_id'] = get_record_ids_level(ms_user, stat, mode)
-        response[f'{mode}_record'] = json.dumps(value, cls=DecimalEncoder)
-    return JsonResponse(response)
 
 
 # 鼠标移到人名上时，展现头像、姓名、id、记录

--- a/back_end/saolei/msuser/views.py
+++ b/back_end/saolei/msuser/views.py
@@ -1,64 +1,14 @@
-import decimal
 import json
 import logging
 
-from django.http import HttpResponseBadRequest, HttpResponseNotFound, JsonResponse
+from django.http import JsonResponse
 from django.views.decorators.http import require_GET
-from django_ratelimit.decorators import ratelimit
 from django_redis import get_redis_connection
 
-from config.global_settings import GameLevels
-from msuser.models import UserMS
-from msuser.utils import RankingField
-from userprofile.models import UserProfile
 from utils import ComplexEncoder
 
 logger = logging.getLogger('userprofile')
 cache = get_redis_connection('saolei_website')
-
-# 根据id获取用户的基本资料、扫雷记录
-# 无需登录就可获取
-
-
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            return float(o)
-        super(DecimalEncoder, self).default(o)
-
-
-def get_records_level(ms_user: UserMS, stat: str, mode: str):
-    return [getattr(ms_user, RankingField(level, stat, mode).name) for level in GameLevels]
-
-
-def get_record_ids_level(ms_user: UserMS, stat: str, mode: str):
-    return [getattr(ms_user, RankingField(level, stat, mode).id_name) for level in GameLevels]
-
-
-# 鼠标移到人名上时，展现头像、姓名、id、记录
-@ratelimit(key='ip', rate='5/s')
-@require_GET
-def get_info_abstract(request):
-    # 此处要防攻击
-    if not (user_id := request.GET.get('id')):
-        return HttpResponseBadRequest()
-    if not (user := UserProfile.objects.filter(id=user_id).first()):
-        return HttpResponseNotFound()
-    ms_user = user.userms
-
-    response = {
-        'record_abstract': json.dumps(
-            {
-                'timems': get_records_level(ms_user, 'timems', 'std'),
-                'bvs': get_records_level(ms_user, 'bvs', 'std'),
-                'timems_id': get_record_ids_level(ms_user, 'timems', 'std'),
-                'bvs_id': get_record_ids_level(ms_user, 'bvs', 'std'),
-            },
-            cls=DecimalEncoder,
-        ),
-    }
-
-    return JsonResponse(response)
 
 
 # 从redis获取用户排行榜

--- a/back_end/saolei/saolei/api.py
+++ b/back_end/saolei/saolei/api.py
@@ -3,6 +3,7 @@ from ninja import NinjaAPI, Redoc
 from accountlink.api import router as accountlink_router
 from common.api import router as common_router
 from customranking.api import router as customranking_router
+from msuser.api import router as msuser_router
 from userprofile.api import router as userprofile_router
 from utils.exceptions import ExceptionToResponse
 from videomanager.api import router as videomanager_router
@@ -14,6 +15,7 @@ api.add_router('/userprofile/', userprofile_router)
 api.add_router('/accountlink/', accountlink_router)
 api.add_router('/video/', videomanager_router)
 api.add_router('/customranking/', customranking_router)
+api.add_router('/msuser/', msuser_router)
 
 
 @api.exception_handler(ExceptionToResponse)

--- a/front_end/cypress/e2e/accountlink.cy.ts
+++ b/front_end/cypress/e2e/accountlink.cy.ts
@@ -131,9 +131,9 @@ describe('Account Link', () => {
         cy.flushDatabase();
 
         // 注册用户
-        cy.register(STAFF.id, STAFF.username, STAFF.email, STAFF.password);
+        cy.registerUser(STAFF);
         cy.setStaff(STAFF.id);
-        cy.register(USER.id, USER.username, USER.email, USER.password);
+        cy.registerUser(USER);
     });
 
     it('Guest View - No Account Links', () => {

--- a/front_end/cypress/e2e/bugfix/user-video.cy.ts
+++ b/front_end/cypress/e2e/bugfix/user-video.cy.ts
@@ -46,7 +46,7 @@ function waitForVideoList(count: number) {
 describe('User Videos', () => {
     it('Before All', () => {
         cy.flushDatabase();
-        cy.register(USER.id, USER.username, USER.email, USER.password);
+        cy.registerUser(USER);
         createVideo(31000);
     });
 

--- a/front_end/cypress/e2e/gsc.cy.ts
+++ b/front_end/cypress/e2e/gsc.cy.ts
@@ -66,10 +66,10 @@ describe('GSC', () => {
         cy.flushDatabase();
 
         // 注册用户
-        cy.register(HOST.id, HOST.username, HOST.email, HOST.password);
-        cy.register(STAFF.id, STAFF.username, STAFF.email, STAFF.password);
+        cy.registerUser(HOST);
+        cy.registerUser(STAFF);
         cy.setStaff(STAFF.id);
-        cy.register(USER.id, USER.username, USER.email, USER.password);
+        cy.registerUser(USER);
     });
 
     it('Create GSC', () => {

--- a/front_end/cypress/e2e/profile.cy.ts
+++ b/front_end/cypress/e2e/profile.cy.ts
@@ -13,7 +13,12 @@ describe('Personal Profile', () => {
         cy.flushDatabase();
 
         // 注册并登录用户
-        cy.register(USER_ID, USERNAME, 'test@email.com', PASSWORD);
+        cy.registerUser({
+            id: USER_ID,
+            username: USERNAME,
+            email: 'test@email.com',
+            password: PASSWORD,
+        });
         cy.login(USERNAME, PASSWORD);
     });
 

--- a/front_end/cypress/e2e/ranking.cy.ts
+++ b/front_end/cypress/e2e/ranking.cy.ts
@@ -1,0 +1,72 @@
+describe('rankings backed by dangerzone fixtures', () => {
+    beforeEach(() => {
+        cy.flushDatabase();
+        cy.clearLocalStorage();
+    });
+
+    it('shows speed ranking only after the user binds the video identifier', () => {
+        const user = {
+            id: 1,
+            username: 'speed_ranker',
+            realname: 'Speed Ranker',
+        };
+        const identifier = 'speed-ranking-e2e';
+
+        cy.registerUser(user);
+        cy.createIdentifier(identifier);
+        cy.createVideo({ user_id: user.id, identifier, level: 'b', timems: 7000, bv: 10 });
+        cy.createVideo({ user_id: user.id, identifier, level: 'i', timems: 12000, bv: 30 });
+        cy.createVideo({ user_id: user.id, identifier, level: 'e', timems: 30000, bv: 100 });
+
+        cy.intercept('GET', '**/msuser/player_rank/**').as('speedRank');
+        cy.visit('/#/ranking/speed');
+        cy.wait('@speedRank').its('response.body.players').should('deep.equal', []);
+        cy.contains('49.000').should('not.exist');
+
+        cy.bindIdentifier(user.id, identifier, 3);
+
+        cy.reload();
+        cy.wait('@speedRank').its('response.body.players').should('have.length', 8);
+        cy.contains('Speed Ranker').should('be.visible');
+        cy.contains('7.000').should('be.visible');
+        cy.contains('12.000').should('be.visible');
+        cy.contains('30.000').should('be.visible');
+        cy.contains('49.000').should('be.visible');
+    });
+
+    it('shows pluck ranking only after the user binds the video identifier', () => {
+        const user = {
+            id: 1,
+            username: 'pluck_ranker',
+            realname: 'Pluck Ranker',
+        };
+        const identifier = 'pluck-ranking-e2e';
+
+        cy.registerUser(user);
+        cy.createIdentifier(identifier);
+        cy.createVideo({
+            user_id: user.id,
+            identifier,
+            level: 'c8_8_40',
+            timems: 10000,
+            bv: 40,
+            pluck: 0.123456,
+        });
+
+        cy.intercept('GET', '**/api/customranking/pluck?**').as('pluckRank');
+        cy.visit('/#/ranking/density');
+        cy.wait('@pluckRank').its('response.body').should('deep.include', {
+            count: 0,
+        });
+        cy.contains('0.123456').should('not.exist');
+
+        cy.bindIdentifier(user.id, identifier, 1);
+
+        cy.reload();
+        cy.wait('@pluckRank').its('response.body.count').should('eq', 1);
+        cy.contains('Pluck Ranker').should('be.visible');
+        cy.contains('0.123456').should('be.visible');
+        cy.contains('10.000').should('be.visible');
+        cy.contains('40').should('be.visible');
+    });
+});

--- a/front_end/cypress/e2e/staff-logs.cy.ts
+++ b/front_end/cypress/e2e/staff-logs.cy.ts
@@ -31,7 +31,7 @@ describe('Staff logs', () => {
     beforeEach(() => {
         void Cypress.session.clearAllSavedSessions();
         cy.flushDatabase();
-        cy.register(STAFF.id, STAFF.username, STAFF.email, STAFF.password);
+        cy.registerUser(STAFF);
         cy.setStaff(STAFF.id);
         writeLog(LOG_FILE, LOG_CONTENT);
     });

--- a/front_end/cypress/support/commands.ts
+++ b/front_end/cypress/support/commands.ts
@@ -117,6 +117,7 @@ Cypress.Commands.add('mockGetEmailCode', (options) => {
 
 Cypress.Commands.add('mockRegister', () => {
     cy.intercept('POST', '/userprofile/register', (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- Cypress 将拦截请求体类型标为 any；这里测试环境固定为 form-urlencoded 字符串。
         const params = new URLSearchParams(req.body);
         const email_captcha = params.get('email_captcha');
 
@@ -136,6 +137,7 @@ Cypress.Commands.add('mockRegister', () => {
 
 Cypress.Commands.add('mockLogin', () => {
     cy.intercept('POST', '/userprofile/login/', (req) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- Cypress 将拦截请求体类型标为 any；这里测试环境固定为 form-urlencoded 字符串。
         const params = new URLSearchParams(req.body);
         const username = params.get('username');
         const password = params.get('password');

--- a/front_end/cypress/support/e2e.ts
+++ b/front_end/cypress/support/e2e.ts
@@ -18,6 +18,36 @@
 import './commands';
 import 'cypress-real-events';
 
+const DANGERZONE_URL = 'http://127.0.0.1:8000/dangerzone';
+
+interface DangerzoneUser {
+    id: number;
+    username: string;
+    email?: string;
+    password?: string;
+    realname?: string;
+}
+
+interface DangerzoneVideo {
+    user_id: number;
+    identifier: string;
+    level: string;
+    timems: number;
+    bv: number;
+    state?: string;
+    software?: string;
+    mode?: string;
+    file_size?: number;
+    left?: number;
+    right?: number;
+    double?: number;
+    left_ce?: number;
+    right_ce?: number;
+    double_ce?: number;
+    path?: number;
+    pluck?: number;
+}
+
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace Cypress {
@@ -35,14 +65,29 @@ declare global {
             flushDatabase(): void;
 
             /**
-             * 注册一个账号。如果该账号已存在，则报错。
-             * @param {number} id - 用户ID
-             * @param {string} username - 用户名
-             * @param {string} email - 邮箱
-             * @param {string} password - 密码
-             * @example cy.register('user', 'user@example.com', 'password');
-             * */
-            register(id: number, username: string, email: string, password: string): void;
+             * 调用 dangerzone API。仅在后端 E2E_TEST 模式可用。
+             */
+            dangerzonePost<T = unknown>(path: string, body?: object): Chainable<Response<T>>;
+
+            /**
+             * 注册测试用户。
+             */
+            registerUser(user: DangerzoneUser): Chainable<Response<unknown>>;
+
+            /**
+             * 创建测试录像。
+             */
+            createVideo(video: DangerzoneVideo): Chainable<Response<{ id: number }>>;
+
+            /**
+             * 创建测试标识。
+             */
+            createIdentifier(identifier: string, safe?: boolean): Chainable<Response<unknown>>;
+
+            /**
+             * 将测试标识绑定到指定用户，可选断言受影响录像数。
+             */
+            bindIdentifier(userId: number, identifier: string, expectedChangedCount?: number): Chainable<Response<{ changed_count: number }>>;
 
             /**
              * 将指定用户设为管理员。
@@ -91,23 +136,65 @@ beforeEach(() => {
     });
 });
 
-Cypress.Commands.add('register', (id: number, username: string, email: string, password: string) => {
-    cy.request({
+Cypress.Commands.add('dangerzonePost', <T = unknown>(path: string, body: object = {}) => {
+    return cy.request<T>({
         method: 'POST',
-        url: 'http://127.0.0.1:8000/dangerzone/register',
-        body: {
-            id: id,
-            username: username,
-            email: email,
-            password: password,
-        },
+        url: `${DANGERZONE_URL}/${path}`,
+        body,
+    });
+});
+
+Cypress.Commands.add('registerUser', (user: DangerzoneUser) => {
+    return cy.dangerzonePost('register', {
+        id: user.id,
+        username: user.username,
+        email: user.email ?? `${user.username}@example.com`,
+        password: user.password ?? 'password',
+        realname: user.realname,
+    });
+});
+
+Cypress.Commands.add('createVideo', (video: DangerzoneVideo) => {
+    return cy.dangerzonePost<{ id: number }>('create_video', {
+        state: 'd',
+        software: 'e',
+        mode: '00',
+        file_size: 1024,
+        left: 100,
+        right: 50,
+        double: 25,
+        left_ce: 100,
+        right_ce: 50,
+        double_ce: 25,
+        path: 1000,
+        ...video,
+    });
+});
+
+Cypress.Commands.add('createIdentifier', (identifier: string, safe = true) => {
+    return cy.dangerzonePost('create_identifier', {
+        identifier,
+        safe,
+    });
+});
+
+Cypress.Commands.add('bindIdentifier', (userId: number, identifier: string, expectedChangedCount?: number) => {
+    return cy.dangerzonePost<{ changed_count: number }>('bind_identifier', {
+        user_id: userId,
+        identifier,
+        safe: true,
+    }).then((response) => {
+        if (expectedChangedCount !== undefined) {
+            expect(response.body.changed_count).to.eq(expectedChangedCount);
+        }
+        return response;
     });
 });
 
 Cypress.Commands.add('setStaff', (id: number) => {
     cy.request({
         method: 'POST',
-        url: 'http://127.0.0.1:8000/dangerzone/setstaff',
+        url: `${DANGERZONE_URL}/setstaff`,
         body: {
             id: id,
         },
@@ -132,13 +219,13 @@ Cypress.Commands.add('login', (username: string, password: string) => {
 });
 
 Cypress.Commands.add('deleteUser', () => {
-    cy.request('POST', 'http://127.0.0.1:8000/dangerzone/delete_user').then((response) => {
+    cy.request('POST', `${DANGERZONE_URL}/delete_user`).then((response) => {
         expect(response.status).to.eq(200);
     });
 });
 
 Cypress.Commands.add('flushDatabase', () => {
-    cy.request('POST', 'http://127.0.0.1:8000/dangerzone/flush_database').then((response) => {
+    cy.request('POST', `${DANGERZONE_URL}/flush_database`).then((response) => {
         expect(response.status).to.eq(200);
     });
 });

--- a/front_end/eslint.config.js
+++ b/front_end/eslint.config.js
@@ -231,7 +231,7 @@ export default defineConfig({
         '@typescript-eslint/no-redeclare': 'off',
         '@typescript-eslint/no-magic-numbers': 'off', // TODO
         '@typescript-eslint/no-unnecessary-condition': 'off', // false positive很多，参考https://typescript-eslint.io/rules/no-unnecessary-condition/#values-modified-within-function-calls
-        '@typescript-eslint/no-unsafe-argument': 'off', // TODO：牵扯到的内容很多，包括后端API重构等
+        // '@typescript-eslint/no-unsafe-argument': 'off', // TODO：牵扯到的内容很多，包括后端API重构等
         '@typescript-eslint/no-unsafe-assignment': 'off', // TODO：牵扯到的内容很多，包括后端API重构等
         '@typescript-eslint/no-unsafe-member-access': 'off', // TODO：牵扯到的内容很多，包括后端API重构等
         '@typescript-eslint/no-unsafe-type-assertion': 'off', // 和Vue的PropType冲突
@@ -247,6 +247,9 @@ export default defineConfig({
 }, {
     files: ['**/*.cy.ts'],
     rules: {
+        // Cypress 组件测试中的 .vue 组件导入在 typescript-eslint 的 project service 中可能被解析为 error type，
+        // 传给 cy.mount/helper 时会触发 no-unsafe-argument；这类报错不代表运行时参数不安全。
+        '@typescript-eslint/no-unsafe-argument': 'off',
         '@typescript-eslint/no-unused-expressions': 'off',
     },
 }, {

--- a/front_end/eslint.config.js
+++ b/front_end/eslint.config.js
@@ -231,7 +231,6 @@ export default defineConfig({
         '@typescript-eslint/no-redeclare': 'off',
         '@typescript-eslint/no-magic-numbers': 'off', // TODO
         '@typescript-eslint/no-unnecessary-condition': 'off', // false positive很多，参考https://typescript-eslint.io/rules/no-unnecessary-condition/#values-modified-within-function-calls
-        // '@typescript-eslint/no-unsafe-argument': 'off', // TODO：牵扯到的内容很多，包括后端API重构等
         '@typescript-eslint/no-unsafe-assignment': 'off', // TODO：牵扯到的内容很多，包括后端API重构等
         '@typescript-eslint/no-unsafe-member-access': 'off', // TODO：牵扯到的内容很多，包括后端API重构等
         '@typescript-eslint/no-unsafe-type-assertion': 'off', // 和Vue的PropType冲突

--- a/front_end/src/components/PlayerName.cy.ts
+++ b/front_end/src/components/PlayerName.cy.ts
@@ -6,10 +6,18 @@ import $axios from '@/http';
 import i18n from '@/i18n';
 
 const recordAbstract = {
-    timems: [12345, 45678, 78901],
-    timems_id: [101, 102, 103],
-    bvs: [1.2345, 2.3456, 3.4567],
-    bvs_id: [201, 202, 203],
+    b_timems_std: 12345,
+    i_timems_std: 45678,
+    e_timems_std: 78901,
+    b_timems_id_std: 101,
+    i_timems_id_std: 102,
+    e_timems_id_std: 103,
+    b_bvs_std: 1.2345,
+    i_bvs_std: 2.3456,
+    e_bvs_std: 3.4567,
+    b_bvs_id_std: 201,
+    i_bvs_id_std: 202,
+    e_bvs_id_std: 203,
 };
 const user = {
     id: 42,
@@ -37,8 +45,8 @@ function mockUserInfo(response: StaticResponse = { body: [user] }) {
 }
 
 function mockRecordAbstract() {
-    cy.intercept('GET', '/msuser/info_abstract/**', {
-        body: { record_abstract: JSON.stringify(recordAbstract) },
+    cy.intercept({ method: 'GET', pathname: '/api/msuser/records_abstract' }, {
+        body: recordAbstract,
     }).as('fetchAbstract');
 }
 

--- a/front_end/src/components/PlayerName.vue
+++ b/front_end/src/components/PlayerName.vue
@@ -41,28 +41,28 @@
                                 {{ t('common.level.shortb') }}
                             </div>
                             <div>
-                                <PreviewNumber :id="+b_t_id" :text="ms_to_s(b_t)" />
+                                <PreviewNumber :id="recordIdValue(b_t_id)" :text="ms_to_s(b_t)" />
                             </div>
                             <div>
-                                <PreviewNumber :id="+b_bvs_id" :text="to_fixed_n(b_bvs, 3)" />
+                                <PreviewNumber :id="recordIdValue(b_bvs_id)" :text="to_fixed_n(b_bvs, 3)" />
                             </div>
                             <div>
                                 {{ t('common.level.shorti') }}
                             </div>
                             <div>
-                                <PreviewNumber :id="+i_t_id" :text="ms_to_s(i_t)" />
+                                <PreviewNumber :id="recordIdValue(i_t_id)" :text="ms_to_s(i_t)" />
                             </div>
                             <div>
-                                <PreviewNumber :id="+i_bvs_id" :text="to_fixed_n(i_bvs, 3)" />
+                                <PreviewNumber :id="recordIdValue(i_bvs_id)" :text="to_fixed_n(i_bvs, 3)" />
                             </div>
                             <div>
                                 {{ t('common.level.shorte') }}
                             </div>
                             <div>
-                                <PreviewNumber :id="+e_t_id" :text="ms_to_s(e_t)" />
+                                <PreviewNumber :id="recordIdValue(e_t_id)" :text="ms_to_s(e_t)" />
                             </div>
                             <div>
-                                <PreviewNumber :id="+e_bvs_id" :text="to_fixed_n(e_bvs, 3)" />
+                                <PreviewNumber :id="recordIdValue(e_bvs_id)" :text="to_fixed_n(e_bvs, 3)" />
                             </div>
                             <div>
                                 {{ t('common.level.sum') }}
@@ -93,10 +93,10 @@ import { Tippy } from 'vue-tippy';
 import PreviewNumber from '@/components/PreviewNumber.vue';
 import PlayerBadge from '@/components/widgets/PlayerBadge.vue';
 import UserAvatar from '@/components/widgets/UserAvatar.vue';
+import { fetchPlayerRecordAbstract } from '@/services/msuserService';
 import { fetchUserInfo } from '@/services/userService';
 import { local } from '@/store';
 import { ms_to_s, to_fixed_n } from '@/utils';
-import useCurrentInstance from '@/utils/common/useCurrentInstance';
 import { formatName } from '@/utils/strings';
 import { UserProfile } from '@/utils/userprofile';
 
@@ -106,8 +106,6 @@ const props = defineProps({
         default: 0,
     },
 });
-
-const { proxy } = useCurrentInstance();
 
 const user = ref(new UserProfile());
 const loading = ref(false);
@@ -139,34 +137,23 @@ watch(() => props.userId, async (newVal) => {
 const is_loading = ref(true);
 
 const b_t = ref(999999);
-const b_bvs = ref('');
-const b_t_id = ref('');
-const b_bvs_id = ref('');
+const b_bvs = ref(0);
+const b_t_id = ref<number | null>(null);
+const b_bvs_id = ref<number | null>(null);
 const i_t = ref(999999);
-const i_bvs = ref('');
-const i_t_id = ref('');
-const i_bvs_id = ref('');
+const i_bvs = ref(0);
+const i_t_id = ref<number | null>(null);
+const i_bvs_id = ref<number | null>(null);
 const e_t = ref(999999);
-const e_bvs = ref('');
-const e_t_id = ref('');
-const e_bvs_id = ref('');
+const e_bvs = ref(0);
+const e_t_id = ref<number | null>(null);
+const e_bvs_id = ref<number | null>(null);
 
 async function pop_show() {
     if (props.userId === 0) return;
     is_loading.value = true;
 
-    const response = await proxy.$axios.get('/msuser/info_abstract/', {
-        params: {
-            id: props.userId,
-        },
-    });
-
-    const records = JSON.parse(response.data.record_abstract) as {
-        timems: number[];
-        timems_id: string[];
-        bvs: string[];
-        bvs_id: string[];
-    };
+    const records = await fetchPlayerRecordAbstract(props.userId);
 
     [b_t.value, i_t.value, e_t.value] = records.timems;
     [b_t_id.value, i_t_id.value, e_t_id.value] = records.timems_id;
@@ -181,16 +168,20 @@ function pop_hide() {
     i_t.value = 999999;
     b_t.value = 999999;
     e_t.value = 999999;
-    b_t_id.value = '';
-    i_t_id.value = '';
-    e_t_id.value = '';
-    b_bvs.value = '';
-    i_bvs.value = '';
-    e_bvs.value = '';
-    b_bvs_id.value = '';
-    i_bvs_id.value = '';
-    e_bvs_id.value = '';
+    b_t_id.value = null;
+    i_t_id.value = null;
+    e_t_id.value = null;
+    b_bvs.value = 0;
+    i_bvs.value = 0;
+    e_bvs.value = 0;
+    b_bvs_id.value = null;
+    i_bvs_id.value = null;
+    e_bvs_id.value = null;
     is_loading.value = true;
+}
+
+function recordIdValue(id: number | null): number {
+    return id ?? 0;
 }
 
 const i18nMessages = {

--- a/front_end/src/components/PlayerName.vue
+++ b/front_end/src/components/PlayerName.vue
@@ -93,7 +93,7 @@ import { Tippy } from 'vue-tippy';
 import PreviewNumber from '@/components/PreviewNumber.vue';
 import PlayerBadge from '@/components/widgets/PlayerBadge.vue';
 import UserAvatar from '@/components/widgets/UserAvatar.vue';
-import { fetchPlayerRecordAbstract } from '@/services/msuserService';
+import { fetchPlayerRecordsAbstract } from '@/services/msuserService';
 import { fetchUserInfo } from '@/services/userService';
 import { local } from '@/store';
 import { ms_to_s, to_fixed_n } from '@/utils';
@@ -153,12 +153,20 @@ async function pop_show() {
     if (props.userId === 0) return;
     is_loading.value = true;
 
-    const records = await fetchPlayerRecordAbstract(props.userId);
+    const records = await fetchPlayerRecordsAbstract(props.userId);
 
-    [b_t.value, i_t.value, e_t.value] = records.timems;
-    [b_t_id.value, i_t_id.value, e_t_id.value] = records.timems_id;
-    [b_bvs.value, i_bvs.value, e_bvs.value] = records.bvs;
-    [b_bvs_id.value, i_bvs_id.value, e_bvs_id.value] = records.bvs_id;
+    b_t.value = records.b_timems_std;
+    i_t.value = records.i_timems_std;
+    e_t.value = records.e_timems_std;
+    b_t_id.value = records.b_timems_id_std;
+    i_t_id.value = records.i_timems_id_std;
+    e_t_id.value = records.e_timems_id_std;
+    b_bvs.value = records.b_bvs_std;
+    i_bvs.value = records.i_bvs_std;
+    e_bvs.value = records.e_bvs_std;
+    b_bvs_id.value = records.b_bvs_id_std;
+    i_bvs_id.value = records.i_bvs_id_std;
+    e_bvs_id.value = records.e_bvs_id_std;
 
     is_loading.value = false;
 }

--- a/front_end/src/components/PlayerName.vue
+++ b/front_end/src/components/PlayerName.vue
@@ -37,41 +37,25 @@
                             </span>
                         </div>
                         <div v-loading="is_loading" class="record-table">
-                            <div>
-                                {{ t('common.level.shortb') }}
-                            </div>
-                            <div>
-                                <PreviewNumber :id="recordIdValue(b_t_id)" :text="ms_to_s(b_t)" />
-                            </div>
-                            <div>
-                                <PreviewNumber :id="recordIdValue(b_bvs_id)" :text="to_fixed_n(b_bvs, 3)" />
-                            </div>
-                            <div>
-                                {{ t('common.level.shorti') }}
-                            </div>
-                            <div>
-                                <PreviewNumber :id="recordIdValue(i_t_id)" :text="ms_to_s(i_t)" />
-                            </div>
-                            <div>
-                                <PreviewNumber :id="recordIdValue(i_bvs_id)" :text="to_fixed_n(i_bvs, 3)" />
-                            </div>
-                            <div>
-                                {{ t('common.level.shorte') }}
-                            </div>
-                            <div>
-                                <PreviewNumber :id="recordIdValue(e_t_id)" :text="ms_to_s(e_t)" />
-                            </div>
-                            <div>
-                                <PreviewNumber :id="recordIdValue(e_bvs_id)" :text="to_fixed_n(e_bvs, 3)" />
-                            </div>
+                            <template v-for="(record, level) in records">
+                                <div>
+                                    {{ t(`common.level.short${level}`) }}
+                                </div>
+                                <div>
+                                    <PreviewNumber :id="record.timems_id ?? 0" :text="ms_to_s(record.timems)" />
+                                </div>
+                                <div>
+                                    <PreviewNumber :id="record.bvs_id ?? 0" :text="to_fixed_n(record.bvs, 3)" />
+                                </div>
+                            </template>
                             <div>
                                 {{ t('common.level.sum') }}
                             </div>
                             <div style="color: #BF9000;font-weight: bold;">
-                                {{ ms_to_s(b_t + i_t + e_t) }}
+                                {{ ms_to_s(records.b.timems + records.i.timems + records.e.timems) }}
                             </div>
                             <div style="color: #BF9000;font-weight: bold;">
-                                {{ to_fixed_n(b_bvs + i_bvs + e_bvs, 3) }}
+                                {{ to_fixed_n(records.b.bvs + records.i.bvs + records.e.bvs, 3) }}
                             </div>
                         </div>
                     </div>
@@ -93,10 +77,11 @@ import { Tippy } from 'vue-tippy';
 import PreviewNumber from '@/components/PreviewNumber.vue';
 import PlayerBadge from '@/components/widgets/PlayerBadge.vue';
 import UserAvatar from '@/components/widgets/UserAvatar.vue';
+import type { UserRecordLevel, UserRecordsAbstractResponse } from '@/services/msuserService';
 import { fetchPlayerRecordsAbstract } from '@/services/msuserService';
 import { fetchUserInfo } from '@/services/userService';
 import { local } from '@/store';
-import { ms_to_s, to_fixed_n } from '@/utils';
+import { createEnumMap, ms_to_s, to_fixed_n } from '@/utils';
 import { formatName } from '@/utils/strings';
 import { UserProfile } from '@/utils/userprofile';
 
@@ -136,60 +121,55 @@ watch(() => props.userId, async (newVal) => {
 
 const is_loading = ref(true);
 
-const b_t = ref(999999);
-const b_bvs = ref(0);
-const b_t_id = ref<number | null>(null);
-const b_bvs_id = ref<number | null>(null);
-const i_t = ref(999999);
-const i_bvs = ref(0);
-const i_t_id = ref<number | null>(null);
-const i_bvs_id = ref<number | null>(null);
-const e_t = ref(999999);
-const e_bvs = ref(0);
-const e_t_id = ref<number | null>(null);
-const e_bvs_id = ref<number | null>(null);
+interface PlayerNameRecord {
+    timems: number;
+    bvs: number;
+    timems_id: number | null;
+    bvs_id: number | null;
+}
+
+const recordLevels = ['b', 'i', 'e'] as const;
+
+const defaultRecord: PlayerNameRecord = {
+    timems: 999999,
+    bvs: 0,
+    timems_id: null,
+    bvs_id: null,
+};
+
+const records = ref(createEnumMap(recordLevels, defaultRecord));
+
+function createRecord(data: UserRecordsAbstractResponse, level: UserRecordLevel): PlayerNameRecord {
+    return {
+        timems: data[`${level}_timems_std`],
+        bvs: data[`${level}_bvs_std`],
+        timems_id: data[`${level}_timems_id_std`],
+        bvs_id: data[`${level}_bvs_id_std`],
+    };
+}
+
+function setRecords(data: UserRecordsAbstractResponse) {
+    records.value = {
+        b: createRecord(data, 'b'),
+        i: createRecord(data, 'i'),
+        e: createRecord(data, 'e'),
+    };
+}
 
 async function pop_show() {
     if (props.userId === 0) return;
     is_loading.value = true;
 
-    const records = await fetchPlayerRecordsAbstract(props.userId);
-
-    b_t.value = records.b_timems_std;
-    i_t.value = records.i_timems_std;
-    e_t.value = records.e_timems_std;
-    b_t_id.value = records.b_timems_id_std;
-    i_t_id.value = records.i_timems_id_std;
-    e_t_id.value = records.e_timems_id_std;
-    b_bvs.value = records.b_bvs_std;
-    i_bvs.value = records.i_bvs_std;
-    e_bvs.value = records.e_bvs_std;
-    b_bvs_id.value = records.b_bvs_id_std;
-    i_bvs_id.value = records.i_bvs_id_std;
-    e_bvs_id.value = records.e_bvs_id_std;
+    const data = await fetchPlayerRecordsAbstract(props.userId);
+    setRecords(data);
 
     is_loading.value = false;
 }
 
 // 用户记录小弹窗关闭后，删除其中的数据
 function pop_hide() {
-    i_t.value = 999999;
-    b_t.value = 999999;
-    e_t.value = 999999;
-    b_t_id.value = null;
-    i_t_id.value = null;
-    e_t_id.value = null;
-    b_bvs.value = 0;
-    i_bvs.value = 0;
-    e_bvs.value = 0;
-    b_bvs_id.value = null;
-    i_bvs_id.value = null;
-    e_bvs_id.value = null;
+    records.value = createEnumMap(recordLevels, defaultRecord);
     is_loading.value = true;
-}
-
-function recordIdValue(id: number | null): number {
-    return id ?? 0;
 }
 
 const i18nMessages = {

--- a/front_end/src/components/accountlinks/VideoImportQueue.vue
+++ b/front_end/src/components/accountlinks/VideoImportQueue.vue
@@ -102,10 +102,10 @@ import { useI18n } from 'vue-i18n';
 import { httpErrorNotification } from '@/components/Notifications';
 import DjangoTaskResultStatusBadge from '@/components/widgets/DjangoTaskResultStatusBadge.vue';
 import GameLevelIcon from '@/components/widgets/GameLevelIcon.vue';
-import type { SaoleiVideo, SaoleiVideoRaw } from '@/utils/accountlinks';
+import { fetchSaoleiImportVideos } from '@/services/accountLinkService';
+import type { SaoleiVideo } from '@/utils/accountlinks';
 import { preview } from '@/utils/common/PlayerDialog';
 import { DjangoTaskResultStatusOptions } from '@/utils/common/structInterface';
-import useCurrentInstance from '@/utils/common/useCurrentInstance';
 import { MS_Levels } from '@/utils/ms_const';
 import { utc_to_local_format } from '@/utils/system/tools';
 
@@ -121,7 +121,6 @@ const filters = ref({
     level: { value: null, matchMode: FilterMatchMode.EQUALS },
 });
 
-const { proxy } = useCurrentInstance();
 const { t } = useI18n();
 
 const tableData = ref<SaoleiVideo[]>([]);
@@ -130,24 +129,12 @@ const importing = ref(false);
 function refresh() {
     tableData.value.splice(0, tableData.value.length);
     if (!props.saoleiId) return;
-    proxy.$axios.get('accountlink/saolei/videolist/get/', {
-        params: {
-            saolei_id: props.saoleiId,
-        },
-    }).then((response) => {
-        tableData.value = preprocessTable(response.data);
+    fetchSaoleiImportVideos(props.saoleiId).then((data) => {
+        tableData.value = data;
     }).catch(httpErrorNotification);
 }
 
 watch(() => props.saoleiId, refresh, { immediate: true });
-
-function preprocessTable(data: SaoleiVideoRaw[]): SaoleiVideo[] {
-    data.forEach((video) => {
-        video.import_video__id ??= 0;
-        video.import_task__status ??= 'NULL';
-    });
-    return data as SaoleiVideo[];
-}
 </script>
 
 <style lang="less" scoped>

--- a/front_end/src/main.ts
+++ b/front_end/src/main.ts
@@ -14,6 +14,7 @@ import { pinia } from './store/create';
 
 import i18n from '@/i18n';
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- 根 .vue 组件在 typescript-eslint 中可能被解析为 error type；vue-tsc 已负责 SFC 类型校验。
 const app = createApp(App);
 
 if (import.meta.env.DEV) {

--- a/front_end/src/services/accountLinkService.ts
+++ b/front_end/src/services/accountLinkService.ts
@@ -1,16 +1,31 @@
 import $axios from '@/http';
 import { AccountLinks } from '@/utils/accountlinks';
-import type { AccountLinkPlatform, AccountLinkQueueResponse, AccountLinksResponse } from '@/utils/accountlinks';
+import type { AccountLinkPlatform, AccountLinkQueueResponse, AccountLinksResponse, SaoleiVideo, SaoleiVideoRaw } from '@/utils/accountlinks';
 
 export async function fetchAccountLinks(userId: number): Promise<AccountLinks> {
-    const { data } = await $axios.get(`/api/accountlink/${userId}`);
-    return new AccountLinks(data as AccountLinksResponse);
+    const { data } = await $axios.get<AccountLinksResponse>(`/api/accountlink/${userId}`);
+    return new AccountLinks(data);
 }
 
 export async function addAccountLink(platform: AccountLinkPlatform, identifier: string): Promise<AccountLinkQueueResponse> {
-    const { data } = await $axios.post('/api/accountlink/create/', {
+    const { data } = await $axios.post<AccountLinkQueueResponse>('/api/accountlink/create/', {
         platform,
         identifier,
     });
-    return data as AccountLinkQueueResponse;
+    return data;
+}
+
+export async function fetchSaoleiImportVideos(saoleiId: number): Promise<SaoleiVideo[]> {
+    const { data } = await $axios.get<SaoleiVideoRaw[]>('accountlink/saolei/videolist/get/', {
+        params: { saolei_id: saoleiId },
+    });
+    return data.map(normalizeSaoleiVideo);
+}
+
+function normalizeSaoleiVideo(video: SaoleiVideoRaw): SaoleiVideo {
+    return {
+        ...video,
+        import_video__id: video.import_video__id ?? 0,
+        import_task__status: video.import_task__status ?? 'NULL',
+    };
 }

--- a/front_end/src/services/msuserService.ts
+++ b/front_end/src/services/msuserService.ts
@@ -37,14 +37,14 @@ export interface FetchPlayerRankParams {
 
 export async function fetchPlayerRecordsAbstract(userId: number): Promise<UserRecordsAbstractResponse> {
     const { data } = await $axios.get<UserRecordsAbstractResponse>('/api/msuser/records_abstract', {
-        params: { id: userId },
+        params: { user_id: userId },
     });
     return data;
 }
 
 export async function fetchUserRecords(userId: number): Promise<UserRecordsResponse> {
     const { data } = await $axios.get<UserRecordsResponse>('/api/msuser/records', {
-        params: { id: userId },
+        params: { user_id: userId },
     });
     return data;
 }

--- a/front_end/src/services/msuserService.ts
+++ b/front_end/src/services/msuserService.ts
@@ -1,0 +1,117 @@
+import $axios from '@/http';
+import type { RecordBIE } from '@/utils/common/structInterface';
+
+type RecordId = number | null;
+
+export interface PlayerRecordAbstract {
+    timems: number[];
+    timems_id: RecordId[];
+    bvs: number[];
+    bvs_id: RecordId[];
+}
+
+interface PlayerRecordAbstractResponse {
+    record_abstract: string;
+}
+
+interface UserRecordsSuccessResponse {
+    id: string;
+    std_record: string;
+    nf_record: string;
+    ng_record: string;
+    dg_record: string;
+}
+
+interface UserRecordsErrorResponse {
+    status: number;
+    msg?: string;
+}
+
+type UserRecordsResponse = UserRecordsSuccessResponse | UserRecordsErrorResponse;
+
+export type UserRecordsResult
+    = {
+        type: 'success';
+        records: RecordBIE[];
+    }
+    | {
+        type: 'error';
+        status: number;
+        msg?: string;
+    };
+
+export interface CustomPluckRecord {
+    level: string;
+    video_id: number;
+    pluck: number;
+}
+
+type PlayerRankValue = number | string;
+
+export interface PlayerRankResponse {
+    total_page: number;
+    players: PlayerRankValue[];
+}
+
+export interface FetchPlayerRankParams {
+    ids: string;
+    sortBy: string;
+    reverse: boolean;
+    indexes: string;
+    page: number;
+}
+
+export async function fetchPlayerRecordAbstract(userId: number): Promise<PlayerRecordAbstract> {
+    const { data } = await $axios.get<PlayerRecordAbstractResponse>('/msuser/info_abstract/', {
+        params: { id: userId },
+    });
+    return JSON.parse(data.record_abstract) as PlayerRecordAbstract;
+}
+
+export async function fetchUserRecords(userId: number): Promise<UserRecordsResult> {
+    const { data } = await $axios.get<UserRecordsResponse>('/msuser/records/', {
+        params: { id: userId },
+    });
+
+    if (!('std_record' in data)) {
+        return {
+            type: 'error',
+            status: data.status,
+            msg: data.msg,
+        };
+    }
+
+    return {
+        type: 'success',
+        records: [
+            parseRecord(data.std_record),
+            parseRecord(data.nf_record),
+            parseRecord(data.ng_record),
+            parseRecord(data.dg_record),
+        ],
+    };
+}
+
+export async function fetchCustomPluckPlayerRecords(userId: number): Promise<CustomPluckRecord[]> {
+    const { data } = await $axios.get<CustomPluckRecord[]>('/api/customranking/pluck/player', {
+        params: { player_id: userId },
+    });
+    return data;
+}
+
+export async function fetchPlayerRank(params: FetchPlayerRankParams): Promise<PlayerRankResponse> {
+    const { data } = await $axios.get<PlayerRankResponse>('/msuser/player_rank/', {
+        params: {
+            ids: params.ids,
+            sort_by: params.sortBy,
+            reverse: params.reverse,
+            indexes: params.indexes,
+            page: params.page,
+        },
+    });
+    return data;
+}
+
+function parseRecord(record: string): RecordBIE {
+    return JSON.parse(record) as RecordBIE;
+}

--- a/front_end/src/services/msuserService.ts
+++ b/front_end/src/services/msuserService.ts
@@ -2,23 +2,17 @@ import $axios from '@/http';
 
 type RecordId = number | null;
 
-export interface PlayerRecordAbstract {
-    timems: number[];
-    timems_id: RecordId[];
-    bvs: number[];
-    bvs_id: RecordId[];
-}
-
-interface PlayerRecordAbstractResponse {
-    record_abstract: string;
-}
-
 export type UserRecordLevel = 'b' | 'e' | 'i';
 export type UserRecordMode = 'dg' | 'nf' | 'ng' | 'std';
 export type UserRecordStat = 'bvs' | 'ioe' | 'path' | 'stnb' | 'timems';
+export type UserRecordsAbstractStat = Extract<UserRecordStat, 'bvs' | 'timems'>;
 type UserRecordValueField = `${UserRecordLevel}_${UserRecordStat}_${UserRecordMode}`;
 type UserRecordIdField = `${UserRecordLevel}_${UserRecordStat}_id_${UserRecordMode}`;
+type UserRecordAbstractValueField = `${UserRecordLevel}_${UserRecordsAbstractStat}_std`;
+type UserRecordAbstractIdField = `${UserRecordLevel}_${UserRecordsAbstractStat}_id_std`;
 export type UserRecordsResponse = Record<UserRecordValueField, number> & Record<UserRecordIdField, number | null>;
+export type UserRecordsAbstractResponse
+    = Record<UserRecordAbstractValueField, number> & Record<UserRecordAbstractIdField, RecordId>;
 
 export interface CustomPluckRecord {
     level: string;
@@ -41,11 +35,11 @@ export interface FetchPlayerRankParams {
     page: number;
 }
 
-export async function fetchPlayerRecordAbstract(userId: number): Promise<PlayerRecordAbstract> {
-    const { data } = await $axios.get<PlayerRecordAbstractResponse>('/msuser/info_abstract/', {
+export async function fetchPlayerRecordsAbstract(userId: number): Promise<UserRecordsAbstractResponse> {
+    const { data } = await $axios.get<UserRecordsAbstractResponse>('/api/msuser/records_abstract', {
         params: { id: userId },
     });
-    return JSON.parse(data.record_abstract) as PlayerRecordAbstract;
+    return data;
 }
 
 export async function fetchUserRecords(userId: number): Promise<UserRecordsResponse> {

--- a/front_end/src/services/msuserService.ts
+++ b/front_end/src/services/msuserService.ts
@@ -1,5 +1,4 @@
 import $axios from '@/http';
-import type { RecordBIE } from '@/utils/common/structInterface';
 
 type RecordId = number | null;
 
@@ -14,31 +13,12 @@ interface PlayerRecordAbstractResponse {
     record_abstract: string;
 }
 
-interface UserRecordsSuccessResponse {
-    id: string;
-    std_record: string;
-    nf_record: string;
-    ng_record: string;
-    dg_record: string;
-}
-
-interface UserRecordsErrorResponse {
-    status: number;
-    msg?: string;
-}
-
-type UserRecordsResponse = UserRecordsSuccessResponse | UserRecordsErrorResponse;
-
-export type UserRecordsResult
-    = {
-        type: 'success';
-        records: RecordBIE[];
-    }
-    | {
-        type: 'error';
-        status: number;
-        msg?: string;
-    };
+export type UserRecordLevel = 'b' | 'e' | 'i';
+export type UserRecordMode = 'dg' | 'nf' | 'ng' | 'std';
+export type UserRecordStat = 'bvs' | 'ioe' | 'path' | 'stnb' | 'timems';
+type UserRecordValueField = `${UserRecordLevel}_${UserRecordStat}_${UserRecordMode}`;
+type UserRecordIdField = `${UserRecordLevel}_${UserRecordStat}_id_${UserRecordMode}`;
+export type UserRecordsResponse = Record<UserRecordValueField, number> & Record<UserRecordIdField, number | null>;
 
 export interface CustomPluckRecord {
     level: string;
@@ -68,28 +48,11 @@ export async function fetchPlayerRecordAbstract(userId: number): Promise<PlayerR
     return JSON.parse(data.record_abstract) as PlayerRecordAbstract;
 }
 
-export async function fetchUserRecords(userId: number): Promise<UserRecordsResult> {
-    const { data } = await $axios.get<UserRecordsResponse>('/msuser/records/', {
+export async function fetchUserRecords(userId: number): Promise<UserRecordsResponse> {
+    const { data } = await $axios.get<UserRecordsResponse>('/api/msuser/records', {
         params: { id: userId },
     });
-
-    if (!('std_record' in data)) {
-        return {
-            type: 'error',
-            status: data.status,
-            msg: data.msg,
-        };
-    }
-
-    return {
-        type: 'success',
-        records: [
-            parseRecord(data.std_record),
-            parseRecord(data.nf_record),
-            parseRecord(data.ng_record),
-            parseRecord(data.dg_record),
-        ],
-    };
+    return data;
 }
 
 export async function fetchCustomPluckPlayerRecords(userId: number): Promise<CustomPluckRecord[]> {
@@ -110,8 +73,4 @@ export async function fetchPlayerRank(params: FetchPlayerRankParams): Promise<Pl
         },
     });
     return data;
-}
-
-function parseRecord(record: string): RecordBIE {
-    return JSON.parse(record) as RecordBIE;
 }

--- a/front_end/src/services/tournamentService.ts
+++ b/front_end/src/services/tournamentService.ts
@@ -1,0 +1,89 @@
+import $axios from '@/http';
+import type { ApiResponse } from '@/utils/common/structInterface';
+import type { TournamentInfo } from '@/utils/tournaments';
+import type { VideoAbstractData } from '@/utils/videoabstract';
+
+export interface GSCTournamentInfo extends TournamentInfo {
+    order: number;
+    token: string;
+}
+
+export interface GSCParticipantResponse {
+    id: number;
+    user__id: number;
+    user__realname: string;
+    bt1st: number;
+    bt20th: number;
+    bt20sum: number;
+    it1st: number;
+    it12th: number;
+    it12sum: number;
+    et1st: number;
+    et5th: number;
+    et5sum: number;
+}
+
+export interface GSCInfoResponse {
+    type: 'success';
+    data: GSCTournamentInfo;
+    results: GSCParticipantResponse[] | null;
+    identifier: string | null;
+}
+
+interface ParticipantVideosParams {
+    userId: number;
+    tournamentId: number;
+}
+
+export async function fetchTournamentList(): Promise<TournamentInfo[]> {
+    const { data } = await $axios.get<ApiResponse<TournamentInfo[]>>('tournament/get_list/');
+    return expectApiSuccess(data, 'tournament/get_list/');
+}
+
+export async function fetchTournament(tournamentId: number | string): Promise<TournamentInfo> {
+    const { data } = await $axios.get<ApiResponse<TournamentInfo>>('tournament/get/', {
+        params: { id: tournamentId },
+    });
+    return expectApiSuccess(data, 'tournament/get/');
+}
+
+export async function fetchGSCInfo(tournamentId: number): Promise<GSCInfoResponse> {
+    const { data } = await $axios.get<GSCInfoResponse>('tournament/gscinfo/', {
+        params: { id: tournamentId },
+    });
+    return data;
+}
+
+export async function fetchParticipantVideos(params: ParticipantVideosParams): Promise<VideoAbstractData[]> {
+    const { data } = await $axios.get<ApiResponse<VideoAbstractData[]>>('tournament/get_videos/participant/', {
+        params: {
+            user_id: params.userId,
+            tournament_id: params.tournamentId,
+        },
+    });
+    return expectApiSuccess(data, 'tournament/get_videos/participant/');
+}
+
+export async function downloadTournamentVideos(tournamentId: number): Promise<ArrayBuffer> {
+    const { data } = await $axios.get<ArrayBuffer>('tournament/download/', {
+        params: { tournament_id: tournamentId },
+        responseType: 'arraybuffer',
+    });
+    return data;
+}
+
+export async function downloadParticipantTournamentVideos(params: ParticipantVideosParams): Promise<ArrayBuffer> {
+    const { data } = await $axios.get<ArrayBuffer>('tournament/download/participant/', {
+        params: {
+            user_id: params.userId,
+            tournament_id: params.tournamentId,
+        },
+        responseType: 'arraybuffer',
+    });
+    return data;
+}
+
+function expectApiSuccess<T>(response: ApiResponse<T>, endpoint: string): T {
+    if (response.type === 'success') return response.data;
+    throw new Error(response.msg ?? `${endpoint} failed`);
+}

--- a/front_end/src/services/videoService.ts
+++ b/front_end/src/services/videoService.ts
@@ -1,0 +1,17 @@
+import $axios from '@/http';
+import { VideoAbstract } from '@/utils/videoabstract';
+import type { VideoRedisInfo } from '@/utils/videoabstract';
+
+type NewestQueueResponse = Record<string, string>;
+
+export async function fetchNewestQueue(): Promise<VideoAbstract[]> {
+    const { data } = await $axios.get<NewestQueueResponse>('/video/newest_queue/', {
+        params: {},
+    });
+
+    return Object.entries(data).map(([key, rawVideoInfo]) => {
+        const videoId = Number.parseInt(key, 10);
+        const videoInfo = JSON.parse(rawVideoInfo) as VideoRedisInfo;
+        return VideoAbstract.fromVideoRedisInfo(videoId, videoInfo);
+    });
+}

--- a/front_end/src/utils/common/structInterface.ts
+++ b/front_end/src/utils/common/structInterface.ts
@@ -13,19 +13,6 @@ export enum LoginStatus {
     IsRetrieve,
 }
 
-export interface RecordBIE {
-    timems: number[];
-    bvs: number[];
-    stnb: number[];
-    ioe: number[];
-    path: number[];
-    timems_id: number[];
-    bvs_id: number[];
-    stnb_id: number[];
-    ioe_id: number[];
-    path_id: number[];
-}
-
 export interface Record {
     timems: number;
     bvs: number;

--- a/front_end/src/utils/tournaments.ts
+++ b/front_end/src/utils/tournaments.ts
@@ -9,7 +9,7 @@ export interface TournamentParticipant {
 
 type LocalizedString = string | Partial<Record<string, string>>;
 
-interface TournamentInfo {
+export interface TournamentInfo {
     [key: string]: unknown;
     id?: number;
     name?: LocalizedString;

--- a/front_end/src/utils/videoabstract.ts
+++ b/front_end/src/utils/videoabstract.ts
@@ -24,7 +24,7 @@ export interface VideoAbstractInfo {
     pluck: number | null;
 }
 
-interface VideoRedisInfo {
+export interface VideoRedisInfo {
     state: string;
     software: string;
     time: string;

--- a/front_end/src/views/HomeView/NewestQueue.vue
+++ b/front_end/src/views/HomeView/NewestQueue.vue
@@ -27,16 +27,14 @@ import { QueueRefreshStatus } from './utils';
 
 import { BaseIconRefresh } from '@/components/common/icon';
 import VideoList from '@/components/VideoList/App.vue';
-import { ArrayUtils } from '@/utils/arrays';
-import useCurrentInstance from '@/utils/common/useCurrentInstance';
+import { fetchNewestQueue } from '@/services/videoService';
 import type { ColumnChoice } from '@/utils/ms_const';
-import { VideoAbstract } from '@/utils/videoabstract';
+import type { VideoAbstract } from '@/utils/videoabstract';
 
 defineProps({
     isActive: { type: Boolean },
 });
 
-const { proxy } = useCurrentInstance();
 const { t } = useI18n();
 
 const queue = ref<VideoAbstract[]>([]);
@@ -51,15 +49,8 @@ async function refresh() {
     setTimeout(() => {
         loadingStatus.value = QueueRefreshStatus.Available;
     }, 5000);
-    await proxy.$axios.get('/video/newest_queue/', {
-        params: {},
-    }).then(function (response) {
-        ArrayUtils.empty(queue.value);
-        for (const key in response.data) {
-            const videoid = Number.parseInt(key);
-            const videoinfo = JSON.parse(response.data[key] as string);
-            queue.value.push(VideoAbstract.fromVideoRedisInfo(videoid, videoinfo));
-        }
+    await fetchNewestQueue().then((data) => {
+        queue.value = data;
     });
     if (loadingStatus.value == QueueRefreshStatus.Refreshing) {
         loadingStatus.value = QueueRefreshStatus.CoolingDown;

--- a/front_end/src/views/RankingView/SpeedRanking.vue
+++ b/front_end/src/views/RankingView/SpeedRanking.vue
@@ -46,7 +46,7 @@
         <div v-for="(player, key) in playerData" style="margin-top: 10px;">
             <span class="rank">{{ key - 19 + (state.CurrentPage) * 20 }}</span>
             <!-- <span class="name">{{ player.name }}</span> -->
-            <PlayerName class="name" :user-id="player.name_id" />
+            <PlayerName class="name" :user-id="player.id" />
             <!-- <span class="beginner">{{ to_fixed_n(player.beginner, 3) }}</span> -->
             <span class="number_wid">
                 <PreviewNumber :id="player.beginner_id" :text="to_fixed_n(player.beginner, 3)" />
@@ -101,8 +101,7 @@ const state = reactive({
 // const test  = reactive({v: 5});
 const playerData = reactive<Player[]>([]);
 interface Player {
-    name_id: number;
-    name: string;
+    id: number;
     beginner: string;
     beginner_id: number;
     intermediate: string;
@@ -162,24 +161,23 @@ const get_player_rank = (page: number) => {
         ids: `${piv}ids`,
         sortBy: `${piv}*->${level_selected.value}`,
         reverse: iv.reverse,
-        indexes: `["#","${piv}*->name","${piv}*->b","${piv}*->b_id","${piv}*->i","${piv}*->i_id","${piv}*->e","${piv}*->e_id","${piv}*->sum"]`,
+        indexes: `["#","${piv}*->b","${piv}*->b_id","${piv}*->i","${piv}*->i_id","${piv}*->e","${piv}*->e_id","${piv}*->sum"]`,
         page: page,
     }).then(function ({ total_page, players }) {
         // console.log(response.data);
         state.Total = total_page;
 
         playerData.splice(0, playerData.length);
-        for (let i = 0; i < players.length / 9; i++) {
+        for (let i = 0; i < players.length / 8; i++) {
             playerData.push({
-                name_id: Number(players[i * 9]),
-                name: String(players[i * 9 + 1]),
-                beginner: formatRankValue(players[i * 9 + 2]),
-                beginner_id: Number(players[i * 9 + 3]),
-                intermediate: formatRankValue(players[i * 9 + 4]),
-                intermediate_id: Number(players[i * 9 + 5]),
-                expert: formatRankValue(players[i * 9 + 6]),
-                expert_id: Number(players[i * 9 + 7]),
-                sum: formatRankValue(players[i * 9 + 8]),
+                id: Number(players[i * 8]),
+                beginner: formatRankValue(players[i * 8 + 1]),
+                beginner_id: Number(players[i * 8 + 2]),
+                intermediate: formatRankValue(players[i * 8 + 3]),
+                intermediate_id: Number(players[i * 8 + 4]),
+                expert: formatRankValue(players[i * 8 + 5]),
+                expert_id: Number(players[i * 8 + 6]),
+                sum: formatRankValue(players[i * 8 + 7]),
             });
         }
         // console.log(playerData);

--- a/front_end/src/views/RankingView/SpeedRanking.vue
+++ b/front_end/src/views/RankingView/SpeedRanking.vue
@@ -79,10 +79,9 @@ import { useI18n } from 'vue-i18n';
 import { httpErrorNotification } from '@/components/Notifications';
 import PlayerName from '@/components/PlayerName.vue';
 import PreviewNumber from '@/components/PreviewNumber.vue';
+import { fetchPlayerRank } from '@/services/msuserService';
 import { ms_to_s, to_fixed_n } from '@/utils';
-import useCurrentInstance from '@/utils/common/useCurrentInstance';
 
-const { proxy } = useCurrentInstance();
 const { t } = useI18n();
 
 // const level_tag_selected = ref("EXPERT");
@@ -159,31 +158,28 @@ const get_player_rank = (page: number) => {
     const iv = index_tags[index_tag_selected.value];
     const mv = mode_tags[mode_tag_selected.value];
     const piv = `player_${iv.key}_${mv.key}_`;
-    proxy.$axios.get('/msuser/player_rank/', {
-        params: {
-            ids: `${piv}ids`,
-            sort_by: `${piv}*->${level_selected.value}`,
-            reverse: iv.reverse,
-            indexes: `["#","${piv}*->name","${piv}*->b","${piv}*->b_id","${piv}*->i","${piv}*->i_id","${piv}*->e","${piv}*->e_id","${piv}*->sum"]`,
-            page: page,
-        },
-    }).then(function ({ data }) {
+    fetchPlayerRank({
+        ids: `${piv}ids`,
+        sortBy: `${piv}*->${level_selected.value}`,
+        reverse: iv.reverse,
+        indexes: `["#","${piv}*->name","${piv}*->b","${piv}*->b_id","${piv}*->i","${piv}*->i_id","${piv}*->e","${piv}*->e_id","${piv}*->sum"]`,
+        page: page,
+    }).then(function ({ total_page, players }) {
         // console.log(response.data);
-        state.Total = data.total_page;
+        state.Total = total_page;
 
-        const { players } = data;
         playerData.splice(0, playerData.length);
         for (let i = 0; i < players.length / 9; i++) {
             playerData.push({
-                name_id: +players[i * 9],
-                name: players[i * 9 + 1],
-                beginner: index_tag_selected.value == 'timems' ? ms_to_s(players[i * 9 + 2]) : players[i * 9 + 2],
-                beginner_id: +players[i * 9 + 3],
-                intermediate: index_tag_selected.value == 'timems' ? ms_to_s(players[i * 9 + 4]) : players[i * 9 + 4],
-                intermediate_id: +players[i * 9 + 5],
-                expert: index_tag_selected.value == 'timems' ? ms_to_s(players[i * 9 + 6]) : players[i * 9 + 6],
-                expert_id: +players[i * 9 + 7],
-                sum: index_tag_selected.value == 'timems' ? ms_to_s(players[i * 9 + 8]) : players[i * 9 + 8],
+                name_id: Number(players[i * 9]),
+                name: String(players[i * 9 + 1]),
+                beginner: formatRankValue(players[i * 9 + 2]),
+                beginner_id: Number(players[i * 9 + 3]),
+                intermediate: formatRankValue(players[i * 9 + 4]),
+                intermediate_id: Number(players[i * 9 + 5]),
+                expert: formatRankValue(players[i * 9 + 6]),
+                expert_id: Number(players[i * 9 + 7]),
+                sum: formatRankValue(players[i * 9 + 8]),
             });
         }
         // console.log(playerData);
@@ -220,6 +216,10 @@ const setSortDirect = (level_tag: string) => {
     }
     get_player_rank(state.CurrentPage);
 };
+
+function formatRankValue(value: number | string): string {
+    return index_tag_selected.value == 'timems' ? ms_to_s(Number(value)) : String(value);
+}
 </script>
 
 <style lang="less" scoped>

--- a/front_end/src/views/TournamentView/GSCDetail.vue
+++ b/front_end/src/views/TournamentView/GSCDetail.vue
@@ -67,9 +67,9 @@ import GSCTokenGuide from './GSCTokenGuide.vue';
 import { BaseIconClose, BaseIconRefresh } from '@/components/common/icon';
 import { httpErrorNotification } from '@/components/Notifications';
 import TournamentStateIcon from '@/components/widgets/TournamentStateIcon.vue';
+import { downloadTournamentVideos, fetchGSCInfo } from '@/services/tournamentService';
 import { store } from '@/store';
 import { LoginStatus } from '@/utils/common/structInterface';
-import useCurrentInstance from '@/utils/common/useCurrentInstance';
 import { streamToZip } from '@/utils/fileIO';
 import { GSCParticipant } from '@/utils/gsc';
 import { TournamentState } from '@/utils/ms_const';
@@ -82,7 +82,6 @@ const props = defineProps({
     },
 });
 
-const { proxy } = useCurrentInstance();
 const { t } = useI18n();
 
 const tournament = ref<Tournament>(new Tournament({}));
@@ -96,21 +95,17 @@ const loading = ref(false);
 
 async function refresh() {
     loading.value = true;
-    await proxy.$axios.get('tournament/gscinfo/', {
-        params: {
-            id: props.id,
-        },
-    }).then((response) => {
-        tournament.value = new Tournament(response.data.data);
-        order.value = response.data.data.order;
-        token.value = response.data.data.token;
+    await fetchGSCInfo(props.id).then((response) => {
+        tournament.value = new Tournament(response.data);
+        order.value = response.data.order;
+        token.value = response.data.token;
 
         if (tournament.value.state === TournamentState.Ongoing && store.login_status === LoginStatus.IsLogin) {
             result.value = [];
-            personaltoken.value = response.data.identifier ?? '';
+            personaltoken.value = response.identifier ?? '';
         } else {
             personaltoken.value = '';
-            result.value = (response.data.results as object[]).map((value) => new GSCParticipant(value));
+            result.value = (response.results ?? []).map((value) => new GSCParticipant(value));
         }
     }).catch(httpErrorNotification);
     loading.value = false;
@@ -135,13 +130,8 @@ function handleAllSummaryTabClose(index: number) {
 }
 
 function downloadAll() {
-    proxy.$axios.get('tournament/download/', {
-        params: {
-            tournament_id: tournament.value.id,
-        },
-        responseType: 'arraybuffer',
-    }).then((response) => {
-        void streamToZip(new Uint8Array(response.data), 'gsc.zip');
+    downloadTournamentVideos(tournament.value.id).then((data) => {
+        void streamToZip(new Uint8Array(data), 'gsc.zip');
     }).catch(httpErrorNotification);
 }
 </script>

--- a/front_end/src/views/TournamentView/GSCPersonalView.vue
+++ b/front_end/src/views/TournamentView/GSCPersonalView.vue
@@ -32,14 +32,12 @@ import BBBvSummary from '@/components/visualization/BBBvSummary/App.vue';
 import BBBvSummaryHeader from '@/components/visualization/BBBvSummary/Header.vue';
 import GSCPersonalSummary from '@/components/visualization/GSCPersonalSummary/App.vue';
 import MultiSelector from '@/components/widgets/MultiSelector.vue';
+import { downloadParticipantTournamentVideos, fetchParticipantVideos } from '@/services/tournamentService';
 import { VideoListConfig } from '@/store';
 import { ArrayUtils } from '@/utils/arrays';
-import type { ApiResponse } from '@/utils/common/structInterface';
-import useCurrentInstance from '@/utils/common/useCurrentInstance';
 import { streamToZip } from '@/utils/fileIO';
 import { ColumnChoices } from '@/utils/ms_const';
 import { VideoAbstract } from '@/utils/videoabstract';
-import type { VideoAbstractData } from '@/utils/videoabstract';
 
 const props = defineProps({
     userId: {
@@ -51,7 +49,6 @@ const props = defineProps({
         required: true,
     },
 });
-const { proxy } = useCurrentInstance();
 const { t } = useI18n();
 const thisColumnChoices = ArrayUtils.sortByReferenceOrder(['bv', 'bvs', 'stnb', 'ces', 'cls', 'corr', 'end_time', 'ioe', 'level', 'state', 'software', 'thrp', 'time', 'upload_time', 'path', 'file_size'], ColumnChoices);
 
@@ -59,29 +56,22 @@ const videos = ref<VideoAbstract[]>([]);
 
 function refresh() {
     if (!props.userId || !props.tournamentId) return;
-    proxy.$axios.get<ApiResponse<VideoAbstractData[]>>('tournament/get_videos/participant/', {
-        params: {
-            user_id: props.userId,
-            tournament_id: props.tournamentId,
-        },
-    }).then((response) => {
-        if (response.data.type === 'success') {
-            videos.value = response.data.data.map((v) => new VideoAbstract(v));
-        }
+    fetchParticipantVideos({
+        userId: props.userId,
+        tournamentId: props.tournamentId,
+    }).then((data) => {
+        videos.value = data.map((video) => new VideoAbstract(video));
     }).catch(httpErrorNotification);
 }
 
 watch(props, refresh, { immediate: true });
 
 function handleDownload() {
-    void proxy.$axios.get('tournament/download/participant/', {
-        params: {
-            user_id: props.userId,
-            tournament_id: props.tournamentId,
-        },
-        responseType: 'arraybuffer',
-    }).then((response) => {
-        void streamToZip(new Uint8Array(response.data), `gsc_${props.userId}.zip`);
+    void downloadParticipantTournamentVideos({
+        userId: props.userId,
+        tournamentId: props.tournamentId,
+    }).then((data) => {
+        void streamToZip(new Uint8Array(data), `gsc_${props.userId}.zip`);
     }).catch(httpErrorNotification);
 }
 </script>

--- a/front_end/src/views/TournamentView/TournamentView.vue
+++ b/front_end/src/views/TournamentView/TournamentView.vue
@@ -26,19 +26,18 @@ import TournamentDetail from './TournamentDetail.vue';
 import TournamentList from './TournamentList.vue';
 
 import { httpErrorNotification } from '@/components/Notifications';
+import { fetchTournament, fetchTournamentList } from '@/services/tournamentService';
 import { local, store } from '@/store';
-import useCurrentInstance from '@/utils/common/useCurrentInstance';
 import { TournamentSeries } from '@/utils/ms_const';
 import { Tournament } from '@/utils/tournaments';
 
-const { proxy } = useCurrentInstance();
 const { t } = useI18n();
 
 const tournamentList = ref<Tournament[]>([]);
 
 function getTournaments() {
-    proxy.$axios.get('tournament/get_list/').then((response) => {
-        for (const tournament of response.data.data) {
+    fetchTournamentList().then((data) => {
+        for (const tournament of data) {
             tournamentList.value.push(new Tournament(tournament));
         }
     }).catch(httpErrorNotification);
@@ -59,12 +58,8 @@ watch(() => route.params.id, async (newId) => {
 
     const tabIndex = store.tournamentTabs.findIndex((tab) => tab.id === Number(newId));
     if (tabIndex === -1) {
-        await proxy.$axios.get('tournament/get/', {
-            params: {
-                id: newId,
-            },
-        }).then((response) => {
-            store.tournamentTabs.push(new Tournament(response.data.data));
+        await fetchTournament(newId).then((data) => {
+            store.tournamentTabs.push(new Tournament(data));
         }).catch(httpErrorNotification);
         currentTab.value = store.tournamentTabs.length.toString();
     } else {

--- a/front_end/src/views/UserView/UserRecordView/App.cy.ts
+++ b/front_end/src/views/UserView/UserRecordView/App.cy.ts
@@ -6,19 +6,41 @@ import { store } from '@/store';
 import { pinia } from '@/store/create';
 import { UserProfile } from '@/utils/userprofile';
 
-function recordBIE(seed: number) {
-    return JSON.stringify({
-        timems: [10000 + seed, 20000 + seed, 30000 + seed],
-        bvs: [1.1 + seed, 2.2 + seed, 3.3 + seed],
-        stnb: [11.1 + seed, 22.2 + seed, 33.3 + seed],
-        ioe: [4.4 + seed, 5.5 + seed, 6.6 + seed],
-        path: [7.7 + seed, 8.8 + seed, 9.9 + seed],
-        timems_id: [101 + seed, 102 + seed, 103 + seed],
-        bvs_id: [201 + seed, 202 + seed, 203 + seed],
-        stnb_id: [301 + seed, 302 + seed, 303 + seed],
-        ioe_id: [401 + seed, 402 + seed, 403 + seed],
-        path_id: [501 + seed, 502 + seed, 503 + seed],
-    });
+type RecordMode = 'dg' | 'nf' | 'ng' | 'std';
+
+function recordFields(mode: RecordMode, seed: number) {
+    return {
+        [`b_timems_${mode}`]: 10000 + seed,
+        [`i_timems_${mode}`]: 20000 + seed,
+        [`e_timems_${mode}`]: 30000 + seed,
+        [`b_bvs_${mode}`]: 1.1 + seed,
+        [`i_bvs_${mode}`]: 2.2 + seed,
+        [`e_bvs_${mode}`]: 3.3 + seed,
+        [`b_stnb_${mode}`]: 11.1 + seed,
+        [`i_stnb_${mode}`]: 22.2 + seed,
+        [`e_stnb_${mode}`]: 33.3 + seed,
+        [`b_ioe_${mode}`]: 4.4 + seed,
+        [`i_ioe_${mode}`]: 5.5 + seed,
+        [`e_ioe_${mode}`]: 6.6 + seed,
+        [`b_path_${mode}`]: 7.7 + seed,
+        [`i_path_${mode}`]: 8.8 + seed,
+        [`e_path_${mode}`]: 9.9 + seed,
+        [`b_timems_id_${mode}`]: 101 + seed,
+        [`i_timems_id_${mode}`]: 102 + seed,
+        [`e_timems_id_${mode}`]: 103 + seed,
+        [`b_bvs_id_${mode}`]: 201 + seed,
+        [`i_bvs_id_${mode}`]: 202 + seed,
+        [`e_bvs_id_${mode}`]: 203 + seed,
+        [`b_stnb_id_${mode}`]: 301 + seed,
+        [`i_stnb_id_${mode}`]: 302 + seed,
+        [`e_stnb_id_${mode}`]: 303 + seed,
+        [`b_ioe_id_${mode}`]: 401 + seed,
+        [`i_ioe_id_${mode}`]: 402 + seed,
+        [`e_ioe_id_${mode}`]: 403 + seed,
+        [`b_path_id_${mode}`]: 501 + seed,
+        [`i_path_id_${mode}`]: 502 + seed,
+        [`e_path_id_${mode}`]: 503 + seed,
+    };
 }
 
 const mountOptions = {
@@ -37,15 +59,12 @@ describe('<UserRecordViewApp />', () => {
         store.$reset();
         store.player = new UserProfile({ id: 42, realname: 'Test Player' });
 
-        cy.intercept({ method: 'GET', pathname: '/msuser/records/' }, {
+        cy.intercept({ method: 'GET', pathname: '/api/msuser/records' }, {
             body: {
-                status: 100,
-                id: 42,
-                realname: 'Test Player',
-                std_record: recordBIE(0),
-                nf_record: recordBIE(10),
-                ng_record: recordBIE(20),
-                dg_record: recordBIE(30),
+                ...recordFields('std', 0),
+                ...recordFields('nf', 10),
+                ...recordFields('ng', 20),
+                ...recordFields('dg', 30),
             },
         }).as('classicRecords');
 

--- a/front_end/src/views/UserView/UserRecordView/App.cy.ts
+++ b/front_end/src/views/UserView/UserRecordView/App.cy.ts
@@ -87,7 +87,7 @@ describe('<UserRecordViewApp />', () => {
     it('loads and renders classical records plus a complete pluck record table', () => {
         cy.mount(App, mountOptions);
 
-        cy.wait('@classicRecords').its('request.query').should('deep.equal', { id: '42' });
+        cy.wait('@classicRecords').its('request.query').should('deep.equal', { user_id: '42' });
         cy.wait('@pluckRecords').its('request.query').should('deep.equal', { player_id: '42' });
 
         cy.contains('Standard').should('be.visible');

--- a/front_end/src/views/UserView/UserRecordView/App.vue
+++ b/front_end/src/views/UserView/UserRecordView/App.vue
@@ -15,25 +15,29 @@ import { nextTick, ref } from 'vue';
 import ClassicalCard from './ClassicalCard.vue';
 import PLuckCard from './PLuckCard.vue';
 
-import type { CustomPluckRecord } from '@/services/msuserService';
+import type {
+    CustomPluckRecord,
+    UserRecordLevel,
+    UserRecordMode,
+    UserRecordsResponse,
+    UserRecordStat,
+} from '@/services/msuserService';
 import { fetchCustomPluckPlayerRecords, fetchUserRecords } from '@/services/msuserService';
 import { store } from '@/store';
-import type { Record, RecordBIE } from '@/utils/common/structInterface';
+import type { Record as PlayerRecord } from '@/utils/common/structInterface';
 
 const loading = ref(true);
-const records = ref<Record[][]>([]);
+const records = ref<PlayerRecord[][]>([]);
 const pluckRecords = ref<CustomPluckRecord[]>([]);
 
 // 此处和父组件配合，等一下从store里获取用户的id
 void nextTick(() => {
-    void fetchUserRecords(store.player.id).then((result) => {
-        if (result.type === 'error') {
-            loading.value = false;
-            ElMessage.error({ message: '不知哪里出现了问题', offset: 68 });
-        } else {
-            records.value = result.records.map(trans_record);
-            loading.value = false;
-        }
+    void fetchUserRecords(store.player.id).then((data) => {
+        records.value = toPlayerRecords(data);
+    }).catch(() => {
+        ElMessage.error({ message: '不知哪里出现了问题', offset: 68 });
+    }).finally(() => {
+        loading.value = false;
     });
 
     void fetchCustomPluckPlayerRecords(store.player.id).then((data) => {
@@ -43,24 +47,44 @@ void nextTick(() => {
     });
 });
 
-// 把记录数据转一下嵌套的结构，做数据格式的适配
-function trans_record(r: RecordBIE): Record[] {
-    const record: Record[] = [];
-    for (let i = 0; i < r.timems.length; i++) {
-        record.push({
-            timems: r.timems[i],
-            bvs: r.bvs[i],
-            stnb: r.stnb[i],
-            ioe: r.ioe[i],
-            path: r.path[i],
-            timems_id: r.timems_id[i],
-            bvs_id: r.bvs_id[i],
-            stnb_id: r.stnb_id[i],
-            ioe_id: r.ioe_id[i],
-            path_id: r.path_id[i],
-        });
-    }
-    return record;
+const recordModes: UserRecordMode[] = ['std', 'nf', 'ng', 'dg'];
+const recordLevels: UserRecordLevel[] = ['b', 'i', 'e'];
+
+function toPlayerRecords(data: UserRecordsResponse): PlayerRecord[][] {
+    return recordModes.map((mode) => recordLevels.map((level) => toPlayerRecord(data, mode, level)));
+}
+
+function toPlayerRecord(data: UserRecordsResponse, mode: UserRecordMode, level: UserRecordLevel): PlayerRecord {
+    return {
+        timems: getStatValue(data, mode, level, 'timems'),
+        bvs: getStatValue(data, mode, level, 'bvs'),
+        stnb: getStatValue(data, mode, level, 'stnb'),
+        ioe: getStatValue(data, mode, level, 'ioe'),
+        path: getStatValue(data, mode, level, 'path'),
+        timems_id: getStatId(data, mode, level, 'timems'),
+        bvs_id: getStatId(data, mode, level, 'bvs'),
+        stnb_id: getStatId(data, mode, level, 'stnb'),
+        ioe_id: getStatId(data, mode, level, 'ioe'),
+        path_id: getStatId(data, mode, level, 'path'),
+    };
+}
+
+function getStatValue(
+    data: UserRecordsResponse,
+    mode: UserRecordMode,
+    level: UserRecordLevel,
+    stat: UserRecordStat,
+): number {
+    return data[`${level}_${stat}_${mode}`];
+}
+
+function getStatId(
+    data: UserRecordsResponse,
+    mode: UserRecordMode,
+    level: UserRecordLevel,
+    stat: UserRecordStat,
+): number {
+    return data[`${level}_${stat}_id_${mode}`] ?? 0;
 }
 </script>
 

--- a/front_end/src/views/UserView/UserRecordView/App.vue
+++ b/front_end/src/views/UserView/UserRecordView/App.vue
@@ -15,46 +15,28 @@ import { nextTick, ref } from 'vue';
 import ClassicalCard from './ClassicalCard.vue';
 import PLuckCard from './PLuckCard.vue';
 
+import type { CustomPluckRecord } from '@/services/msuserService';
+import { fetchCustomPluckPlayerRecords, fetchUserRecords } from '@/services/msuserService';
 import { store } from '@/store';
 import type { Record, RecordBIE } from '@/utils/common/structInterface';
-import useCurrentInstance from '@/utils/common/useCurrentInstance';
-
-interface PluckRecord {
-    level: string;
-    video_id: number;
-    pluck: number;
-}
-
-const { proxy } = useCurrentInstance();
 
 const loading = ref(true);
 const records = ref<Record[][]>([]);
-const pluckRecords = ref<PluckRecord[]>([]);
+const pluckRecords = ref<CustomPluckRecord[]>([]);
 
 // 此处和父组件配合，等一下从store里获取用户的id
 void nextTick(() => {
-    void proxy.$axios.get('/msuser/records/', {
-        params: {
-            id: store.player.id,
-        },
-    }).then(function ({ data }) {
-        if (data.status > 100) {
+    void fetchUserRecords(store.player.id).then((result) => {
+        if (result.type === 'error') {
             loading.value = false;
             ElMessage.error({ message: '不知哪里出现了问题', offset: 68 });
         } else {
-            records.value.push(trans_record(JSON.parse(data.std_record)));
-            records.value.push(trans_record(JSON.parse(data.nf_record)));
-            records.value.push(trans_record(JSON.parse(data.ng_record)));
-            records.value.push(trans_record(JSON.parse(data.dg_record)));
+            records.value = result.records.map(trans_record);
             loading.value = false;
         }
     });
 
-    void proxy.$axios.get<PluckRecord[]>('/api/customranking/pluck/player', {
-        params: {
-            player_id: store.player.id,
-        },
-    }).then(({ data }) => {
+    void fetchCustomPluckPlayerRecords(store.player.id).then((data) => {
         pluckRecords.value = data;
     }).catch(() => {
         ElMessage.error({ message: '自定义密度纪录加载失败', offset: 68 });


### PR DESCRIPTION
- Introduce dedicated front-end services (`msuserService`, `tournamentService`, `videoService`, and extensions to `accountLinkService`) to centralize API calls and response normalization. Refactor multiple components (`PlayerName`, `NewestQueue`, `VideoImportQueue`, `SpeedRanking`, GSC views, `TournamentView`, `UserRecordView`) to use these services instead of `proxy.$axios`, improve typing (export `TournamentInfo`/`VideoRedisInfo`, use `number|null` for ids), and add small helpers (`recordIdValue`, `formatRankValue`).
- Disable the rule where Cypress/Vue SFC types cause false positives, and add inline disables for specific Cypress/main usage.
- Misc: normalize Saolei video fields and parse/convert newest-queue & player-rank payloads.
- Move the user records endpoints from Django views to the Ninja API framework. The response format changes from mode-grouped JSON strings to a flat field structure (e.g., `b_timems_std`, `i_bvs_nf_id`, etc). Update tests, service layer, and components to handle the new response format. Register the msuser router in the main API configuration.
- Add identifier management endpoints to dangerzone API (create/bind/unbind/delete) and include realname support when registering test users. Introduce Cypress dangerzone helpers (`dangerzonePost`, `registerUser`, `createVideo`, `createIdentifier`, `bindIdentifier`) and switch tests to use them. Update existing Cypress tests to use registerUser.
- Add new ranking.cy E2E tests.
- Fix `SpeedRanking.vue` to use `player.id` and adjust index parsing (remove name field).