### PR TITLE
Harden DB and worker startup

### DIFF
--- a/back_end/saolei/saolei/settings.py
+++ b/back_end/saolei/saolei/settings.py
@@ -121,7 +121,13 @@ DATABASES = {
         'HOST': '127.0.0.1',
         # 'HOST': 'mysql',   # docker-compose 中的服务名称
         'PORT': '3306',
-        'CONN_MAX_AGE': None,
+        'CONN_MAX_AGE': 60,
+        'CONN_HEALTH_CHECKS': True,
+        'OPTIONS': {
+            'connect_timeout': 5,
+            'read_timeout': 15,
+            'write_timeout': 15,
+        },
     },
 }
 

--- a/back_end/saolei/start.sh
+++ b/back_end/saolei/start.sh
@@ -8,9 +8,20 @@ echo "静态文件搜集完成。"
 python3 manage.py makemigrations
 python3 manage.py migrate
 
-echo "Starting db_worker..."
-nohup python3 manage.py db_worker & 
-echo "db_worker started."
+if [ "${START_DB_WORKER:-1}" = "1" ]; then
+    mkdir -p logs
+    echo "Starting db_worker after ${DB_WORKER_START_DELAY:-10}s..."
+    (
+        sleep "${DB_WORKER_START_DELAY:-10}"
+        if command -v ionice >/dev/null 2>&1; then
+            exec nice -n "${DB_WORKER_NICE:-10}" ionice -c2 -n7 python3 manage.py db_worker --skip-checks --no-reload --interval "${DB_WORKER_INTERVAL:-2}"
+        fi
+        exec nice -n "${DB_WORKER_NICE:-10}" python3 manage.py db_worker --skip-checks --no-reload --interval "${DB_WORKER_INTERVAL:-2}"
+    ) >> logs/db_worker.log 2>&1 &
+    echo "db_worker scheduled."
+else
+    echo "Skipping db_worker because START_DB_WORKER=${START_DB_WORKER}."
+fi
 
 cp -f default.conf /etc/nginx/conf.d/default.conf
 sudo nginx -s reload

--- a/back_end/saolei/uwsgi.ini
+++ b/back_end/saolei/uwsgi.ini
@@ -18,6 +18,18 @@ master = true
 # 最大进程数
 processes = 5
 
+# nginx returns 504 quickly; stop the matching Django request as well so
+# slow maintenance endpoints cannot occupy all uWSGI workers indefinitely.
+harakiri = 10
+harakiri-verbose = true
+
+# Keep the web process pool healthy during leaks or wedged requests.
+max-requests = 1000
+max-requests-delta = 100
+listen = 128
+die-on-term = true
+need-app = true
+
 # 当服务器退出时自动清理环境
 vacuum = true
 


### PR DESCRIPTION
This patch improves backend stability by adding MySQL connection health checks and explicit read/write timeouts in Django settings. The startup script now conditionally launches db_worker with configurable delay, scheduling, and logging, instead of starting it unconditionally. uWSGI settings also add request timeouts and worker recycling to prevent long-running or wedged requests from exhausting the worker pool.