### PR TITLE
Add /api proxy route to nginx

### DIFF
--- a/back_end/saolei/default.conf
+++ b/back_end/saolei/default.conf
@@ -41,6 +41,11 @@ server {
         try_files $uri $uri.html $uri/ /docs/index.html;
     }
 
+    location ^~ /api/ {
+        include uwsgi_params;
+        uwsgi_pass 127.0.0.1:8000;
+        uwsgi_read_timeout 2;
+    }
 
     location / {
         include uwsgi_params;


### PR DESCRIPTION
Added a dedicated nginx location for /api/ requests, forwarding them to the uwsgi app on 127.0.0.1:8000 with a shorter read timeout. This ensures API routes are matched before the catch-all location and improves backend request handling.

Fix #804 