### PR TITLE
refactor: Centralize color themes into colorThemes store

### DIFF
--- a/front_end/src/components/visualization/BBBvSummary/App.vue
+++ b/front_end/src/components/visualization/BBBvSummary/App.vue
@@ -57,7 +57,8 @@ import Cell from './Cell.vue';
 import Tooltip from './Tooltip.vue';
 import YLabel from './YLabel.vue';
 
-import { BBBvSummaryConfig, colorTheme } from '@/store';
+import { BBBvSummaryConfig } from '@/store';
+import { colorThemes } from '@/store/color';
 import { ArrayUtils } from '@/utils/arrays';
 import { PiecewiseColorScheme } from '@/utils/colors';
 import { setLastDigit } from '@/utils/math';
@@ -104,7 +105,7 @@ const displayBy = computed(() => options.value[BBBvSummaryConfig.value.template]
 const theme = computed(() => {
     if (!(PiecewiseColorSchemeName as readonly string[]).includes(displayBy.value)) return new PiecewiseColorScheme([], []);
     const themeName = getPiecewiseColorSchemeName(displayBy.value as PiecewiseColorSchemeName, props.level);
-    return new PiecewiseColorScheme(colorTheme.value[themeName].colors, colorTheme.value[themeName].thresholds);
+    return colorThemes[themeName].value;
 });
 
 const gridStyle = computed(() => {

--- a/front_end/src/components/visualization/GSCPersonalSummary/SortedColumn.vue
+++ b/front_end/src/components/visualization/GSCPersonalSummary/SortedColumn.vue
@@ -24,8 +24,8 @@ import { useI18n } from 'vue-i18n';
 import Cell from './Cell.vue';
 import { defaultVideos } from './utils';
 
-import { colorTheme } from '@/store';
-import { getTextColor, PiecewiseColorScheme } from '@/utils/colors';
+import { colorThemes } from '@/store/color';
+import { getTextColor } from '@/utils/colors';
 import type { MS_Level } from '@/utils/ms_const';
 import { formatNumberSmart } from '@/utils/strings';
 import type { StandardVideoAbstract } from '@/utils/videoabstract';
@@ -56,11 +56,11 @@ const { t } = useI18n();
 const colorScheme = computed(() => {
     switch (props.sortBy) {
         case 'time':
-            return PiecewiseColorScheme.createFromTheme(colorTheme.value[`${props.level}time`]);
+            return colorThemes[`${props.level}time`].value;
         case 'bvs':
-            return PiecewiseColorScheme.createFromTheme(colorTheme.value.bvs);
+            return colorThemes.bvs.value;
         case 'stnb':
-            return PiecewiseColorScheme.createFromTheme(colorTheme.value.stnb);
+            return colorThemes.stnb.value;
     }
 });
 

--- a/front_end/src/components/visualization/VideoScatter/store.ts
+++ b/front_end/src/components/visualization/VideoScatter/store.ts
@@ -5,9 +5,9 @@ import { defineStore } from 'pinia';
 import { videoToPlotPoint } from './utils';
 
 import { colorTheme, VideoScatterConfig } from '@/store';
+import { colorThemes } from '@/store/color';
 import { pinia } from '@/store/create';
 import { PiecewiseColorScheme } from '@/utils/colors';
-import type { MS_Level } from '@/utils/ms_const';
 import { getPiecewiseColorSchemeName, isStandardLevel } from '@/utils/ms_const';
 import type { VideoAbstract } from '@/utils/videoabstract';
 
@@ -15,11 +15,6 @@ function inShape(video: VideoAbstract, shape: AnyShape) {
     const point = videoToPlotPoint(video, VideoScatterConfig.value.x, VideoScatterConfig.value.y);
     if (point === undefined) return false;
     return shape.contains(point);
-}
-
-function getTimeColorScheme(level: MS_Level) {
-    const name = getPiecewiseColorSchemeName('time', level);
-    return new PiecewiseColorScheme(colorTheme.value[name].colors, colorTheme.value[name].thresholds);
 }
 
 export const VideoScatterStore = defineStore('video-scatter-store', {
@@ -41,9 +36,9 @@ export const VideoScatterStore = defineStore('video-scatter-store', {
                 return (video: VideoAbstract) => (isStandardLevel(video.level) ? colorTheme.value.level[video.level] : colorTheme.value.level.c);
             } else if (colorBy === 'time') {
                 const schemes = {
-                    b: getTimeColorScheme('b'),
-                    i: getTimeColorScheme('i'),
-                    e: getTimeColorScheme('e'),
+                    b: colorThemes.btime.value,
+                    i: colorThemes.itime.value,
+                    e: colorThemes.etime.value,
                 };
                 return (video: VideoAbstract) => (isStandardLevel(video.level) ? schemes[video.level].getColor(video.time) : colorTheme.value.level.e);
             } else {

--- a/front_end/src/components/visualization/WeeklyPersonalSummary/Classic.vue
+++ b/front_end/src/components/visualization/WeeklyPersonalSummary/Classic.vue
@@ -6,13 +6,13 @@
         {{ t('common.level.e') }}{{ t('common.punct.colon') }}{{ ms_to_s(eSum) }}
     </div>
     <div class="cell-list">
-        <Cell v-for="i in 2" :key="`e${i}`" :video="bestE[i]" :color-theme="colorThemes.etime.value" :default-time="240" />
+        <Cell v-for="i in 2" :key="`e${i}`" :video="bestE[i-1]" :color-theme="colorThemes.etime.value" :default-time="240" />
     </div>
     <div class="text text-large" style="margin-top: 0.5em">
         {{ t('common.level.i') }}{{ t('common.punct.colon') }}{{ ms_to_s(iSum) }}
     </div>
     <div class="cell-list">
-        <Cell v-for="i in 5" :key="`i${i}`" :video="bestI[i]" :color-theme="colorThemes.itime.value" :default-time="60" />
+        <Cell v-for="i in 5" :key="`i${i}`" :video="bestI[i-1]" :color-theme="colorThemes.itime.value" :default-time="60" />
     </div>
 </template>
 

--- a/front_end/src/components/visualization/WeeklyPersonalSummary/Classic.vue
+++ b/front_end/src/components/visualization/WeeklyPersonalSummary/Classic.vue
@@ -6,18 +6,13 @@
         {{ t('common.level.e') }}{{ t('common.punct.colon') }}{{ ms_to_s(eSum) }}
     </div>
     <div class="cell-list">
-        <Cell :video="bestE[0]" :color-theme="colorSchemeE" :default-time="240" />
-        <Cell :video="bestE[1]" :color-theme="colorSchemeE" :default-time="240" />
+        <Cell v-for="i in 2" :key="`e${i}`" :video="bestE[i]" :color-theme="colorThemes.etime.value" :default-time="240" />
     </div>
     <div class="text text-large" style="margin-top: 0.5em">
         {{ t('common.level.i') }}{{ t('common.punct.colon') }}{{ ms_to_s(iSum) }}
     </div>
     <div class="cell-list">
-        <Cell :video="bestI[0]" :color-theme="colorSchemeI" :default-time="60" />
-        <Cell :video="bestI[1]" :color-theme="colorSchemeI" :default-time="60" />
-        <Cell :video="bestI[2]" :color-theme="colorSchemeI" :default-time="60" />
-        <Cell :video="bestI[3]" :color-theme="colorSchemeI" :default-time="60" />
-        <Cell :video="bestI[4]" :color-theme="colorSchemeI" :default-time="60" />
+        <Cell v-for="i in 5" :key="`i${i}`" :video="bestI[i]" :color-theme="colorThemes.itime.value" :default-time="60" />
     </div>
 </template>
 
@@ -29,9 +24,8 @@ import { useI18n } from 'vue-i18n';
 
 import Cell from './Cell.vue';
 
-import { colorTheme } from '@/store';
+import { colorThemes } from '@/store/color';
 import { ms_to_s } from '@/utils';
-import { PiecewiseColorScheme } from '@/utils/colors';
 import type { VideoAbstract } from '@/utils/videoabstract';
 import { isWeeklyClassicScoreMode } from '@/utils/weekly';
 
@@ -40,9 +34,6 @@ const props = defineProps({
 });
 
 const { t } = useI18n();
-
-const colorSchemeI = computed(() => PiecewiseColorScheme.createFromTheme(colorTheme.value.itime));
-const colorSchemeE = computed(() => PiecewiseColorScheme.createFromTheme(colorTheme.value.etime));
 
 function bestVideos(videos: VideoAbstract[], level: 'i' | 'e') {
     const filtered = videos.filter((video) => video.level === level && isWeeklyClassicScoreMode(video.mode));

--- a/front_end/src/store/color.ts
+++ b/front_end/src/store/color.ts
@@ -1,0 +1,21 @@
+import { computed } from 'vue';
+
+import { colorTheme } from '.';
+
+import { PiecewiseColorScheme } from '@/utils/colors';
+
+const stnbTheme = computed(() => PiecewiseColorScheme.createFromTheme(colorTheme.value.stnb));
+const ioeTheme = computed(() => PiecewiseColorScheme.createFromTheme(colorTheme.value.ioe));
+const bvsTheme = computed(() => PiecewiseColorScheme.createFromTheme(colorTheme.value.bvs));
+const etimeTheme = computed(() => PiecewiseColorScheme.createFromTheme(colorTheme.value.etime));
+const itimeTheme = computed(() => PiecewiseColorScheme.createFromTheme(colorTheme.value.itime));
+const btimeTheme = computed(() => PiecewiseColorScheme.createFromTheme(colorTheme.value.btime));
+
+export const colorThemes = {
+    stnb: stnbTheme,
+    ioe: ioeTheme,
+    bvs: bvsTheme,
+    etime: etimeTheme,
+    itime: itimeTheme,
+    btime: btimeTheme,
+};


### PR DESCRIPTION
- Add `front_end/src/store/color.ts` which exports computed `PiecewiseColorScheme` objects as colorThemes.
- Update `BBBvSummary`, `GSCPersonalSummary`, `VideoScatter` store, and `WeeklyPersonalSummary` to import `colorThemes` and use the precomputed `.value` themes instead of calling `PiecewiseColorScheme.createFromTheme` or accessing `colorTheme.value` directly.
- Removes duplicated helper logic and unused imports, simplifying theme usage across components.